### PR TITLE
feat: transform JsonSchemaValidationException into ValidatorException

### DIFF
--- a/src/main/java/io/vertx/openapi/contract/OpenAPIVersion.java
+++ b/src/main/java/io/vertx/openapi/contract/OpenAPIVersion.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 
 import static io.vertx.json.schema.Draft.DRAFT202012;
 import static io.vertx.json.schema.Draft.DRAFT4;
+import static io.vertx.json.schema.OutputFormat.Basic;
 import static io.vertx.openapi.contract.OpenAPIContractException.createInvalidContract;
 import static io.vertx.openapi.contract.OpenAPIContractException.createUnsupportedVersion;
 
@@ -76,7 +77,7 @@ public enum OpenAPIVersion {
   }
 
   public Future<SchemaRepository> getRepository(Vertx vertx, String baseUri) {
-    JsonSchemaOptions opts = new JsonSchemaOptions().setDraft(draft).setBaseUri(baseUri);
+    JsonSchemaOptions opts = new JsonSchemaOptions().setDraft(draft).setBaseUri(baseUri).setOutputFormat(Basic);
     return vertx.executeBlocking(p -> {
       SchemaRepository repo = SchemaRepository.create(opts).preloadMetaSchema(vertx.fileSystem());
       for (String ref : schemaFiles) {

--- a/src/test/java/io/vertx/openapi/validation/ExtractReasonTest.java
+++ b/src/test/java/io/vertx/openapi/validation/ExtractReasonTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.json.schema.JsonSchemaValidationException;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.openapi.contract.OpenAPIContract;
+import io.vertx.openapi.test.base.HttpServerTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
+import static io.vertx.core.http.HttpMethod.POST;
+import static io.vertx.openapi.ResourceHelper.getRelatedTestResourcePath;
+import static io.vertx.openapi.validation.ValidatorErrorType.INVALID_VALUE;
+
+/**
+ * Tests indirectly the method {@link ValidatorException#extractReason(JsonSchemaValidationException)}, there is no
+ * real unit test yet, because producing a correct mock of OutputUnit is too much effort.
+ */
+class ExtractReasonTest extends HttpServerTestBase {
+
+  private final Path contractPath =
+    getRelatedTestResourcePath(ExtractReasonTest.class).resolve("guestbook.yaml");
+  private OpenAPIContract contract;
+  private RequestValidator validator;
+
+  private static JsonObject buildGuest(Object name, Object... friends) {
+    return buildGuest(name, null, friends);
+  }
+
+  private static JsonObject buildGuest(Object name, Number age, Object... friends) {
+    JsonObject guest = new JsonObject().put("name", name);
+    if (age != null) {
+      guest.put("age", age);
+    }
+    JsonArray friendsArray = new JsonArray(Arrays.asList(friends));
+    if (!friendsArray.isEmpty()) {
+      guest.put("friends", friendsArray);
+    }
+    return guest;
+  }
+
+  private static JsonObject buildEntry(Object message, Object guest) {
+    return new JsonObject().put("message", message).put("guest", guest);
+  }
+
+  private static Stream<Arguments> testErrorMessage() {
+    JsonObject validGuest = buildGuest("Hodor");
+    JsonObject invalidGuest = buildGuest("Hodor", 13.37);
+    return Stream.of(
+      Arguments.of("Number for message", buildEntry(420, validGuest),
+        "Reason: Instance type number is invalid. Expected string at #/message"),
+      Arguments.of("Boolean for message", buildEntry(true, validGuest),
+        "Reason: Instance type boolean is invalid. Expected string at #/message"),
+      Arguments.of("Number for age of guest", buildEntry("msg", invalidGuest),
+        "Reason: Instance type number is invalid. Expected integer at #/guest/age"),
+      Arguments.of("Number for age of first friend of guest",
+        buildEntry("msg", buildGuest("Hodor", 1337, invalidGuest)),
+        "Reason: Instance type number is invalid. Expected integer at #/guest/friends/0/age")
+    );
+  }
+
+  @BeforeEach
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void setup(Vertx vertx, VertxTestContext testContext) {
+    OpenAPIContract.from(vertx, contractPath.toString()).onComplete(testContext.succeeding(c -> {
+      contract = c;
+      validator = RequestValidator.create(vertx, contract);
+      testContext.completeNow();
+    }));
+  }
+
+  @ParameterizedTest(name = "{index} {0}")
+  @MethodSource
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void testErrorMessage(String scenario, JsonObject payload, String expected, VertxTestContext testContext) {
+    createValidationHandler(validatorException -> assertThat(validatorException).hasMessageThat().endsWith(expected),
+      testContext)
+      .compose(v -> sendJson(payload.toBuffer())).onFailure(testContext::failNow);
+  }
+
+  private Future<HttpClientResponse> sendJson(Buffer json) {
+    return createRequest(POST, "/bookentry").compose(req -> {
+      req.putHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_JSON.toString());
+      return req.send(json);
+    });
+  }
+
+  private Future<Void> createValidationHandler(Consumer<ValidatorException> validatorException,
+    VertxTestContext testContext) {
+
+    return createServer(request -> {
+      validator.validate(request).onSuccess(v -> testContext.failNow("A validation error is expected"))
+        .onFailure(t -> testContext.verify(() -> {
+          assertThat(t).isInstanceOf(ValidatorException.class);
+          ValidatorException exception = (ValidatorException) t;
+          assertThat(exception.type()).isEqualTo(INVALID_VALUE);
+          validatorException.accept(exception);
+          testContext.completeNow();
+        }));
+      request.end();
+    });
+  }
+}

--- a/src/test/java/io/vertx/openapi/validation/impl/RequestValidatorImplTest.java
+++ b/src/test/java/io/vertx/openapi/validation/impl/RequestValidatorImplTest.java
@@ -18,7 +18,6 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonObject;
 import io.vertx.json.schema.JsonSchema;
-import io.vertx.json.schema.OutputUnit;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
@@ -286,7 +285,6 @@ class RequestValidatorImplTest {
       assertThrows(ValidatorException.class, () -> validator.validateParameter(param, new RequestParameterImpl("3")));
     assertThat(exception.type()).isEqualTo(INVALID_VALUE);
     String reason = "Instance type number is invalid. Expected string";
-    assertThat(exception.getReason()).isInstanceOf(OutputUnit.class);
     String expectedMsg =
       "The value of path parameter p1 is invalid. Reason: " + reason;
     assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);
@@ -384,7 +382,6 @@ class RequestValidatorImplTest {
       assertThrows(ValidatorException.class, () -> validator.validateBody(mockedRequestBody, mockedValidatableRequest));
     assertThat(exception.type()).isEqualTo(INVALID_VALUE);
     String reason = "Instance type number is invalid. Expected object";
-    assertThat(exception.getReason()).isInstanceOf(OutputUnit.class);
     String expectedMsg =
       "The value of the request body is invalid. Reason: " + reason;
     assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);

--- a/src/test/resources/io/vertx/openapi/validation/guestbook.yaml
+++ b/src/test/resources/io/vertx/openapi/validation/guestbook.yaml
@@ -1,0 +1,60 @@
+---
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: Guestbook Service
+  license:
+    identifier: MIT
+    name: MIT License
+servers:
+  - url: https://example.com/guestbook/v1
+security:
+  - BasicAuth: [ ]
+paths:
+  "/bookentry":
+    post:
+      summary: Create a new book entry
+      operationId: createEntry
+      tags:
+        - entry
+      requestBody:
+        description: Create a new entry in the guest book
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Entry'
+      responses:
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Entry:
+      type: object
+      required:
+        - guest
+        - message
+      properties:
+        guest:
+          $ref: '#/components/schemas/Guest'
+        message:
+          type: string
+    Guest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
+        friends:
+          type: array
+          items:
+            $ref: '#/components/schemas/Guest'
+    Error:
+      type: object


### PR DESCRIPTION
Signed-off-by: Pascal Krause <pascal.krause@sap.com>

Motivation:

The `checkValidity` method of the `OutputUnit` throws a `JsonSchemaValidationException` which provides detailed information about the validation problem. This change takes advantage of the `JsonSchemaValidationException` by turning it into a `ValidatorException` and adds the location of the error into the top error message.