### PR TITLE
feat: add ResponseValidator

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -7,6 +7,7 @@ Vert.x OpenAPI can:
 
 * parse and validate your OpenAPI contract.
 * parse and validate incoming requests according to your OpenAPI contract.
+* parse and validate outgoing responses according to your OpenAPI contract.
 
 == Using Vert.x OpenAPI
 
@@ -77,7 +78,7 @@ The {@link io.vertx.openapi.contract.OpenAPIContract} interface offers methods t
 {@link examples.ContractExamples#pathParameterOperationExample}
 ----
 
-== Validation
+== Validation of Requests
 
 The {@link io.vertx.openapi.validation.RequestValidator} offers multiple _validate_ methods to validate incoming requests.
 
@@ -94,4 +95,18 @@ The {@link io.vertx.openapi.validation.RequestValidator} also offers a signature
 ----
 
 NOTE: The parameters in a {@link io.vertx.openapi.validation.ValidatableRequest} must be stored in a specific format depending on the style, location and if they are exploded or not, otherwise the {@link io.vertx.openapi.validation.RequestValidator} can't validate the request.
-How this format *MUST* look like is described in the JavaDoc of {@link io.vertx.openapi.validation.RequestValidator}.
+The required format *MUST* exactly look like as described in the JavaDoc of {@link io.vertx.openapi.validation.RequestValidator}.
+
+== Validation of Responses
+
+The {@link io.vertx.openapi.validation.ResponseValidator} offers a _validate_ method to validate responses. {@link io.vertx.openapi.validation.ValidatableResponse} offers multiple _create_ methods to build validatable responses easily.
+
+In case that the validation of a response has passed, the returned {@link io.vertx.openapi.validation.ValidatedResponse} can directly be sent back to the client.
+
+[source,$lang]
+----
+{@link examples.ValidationExamples#validatableResponse}
+----
+
+NOTE: The parameters in a {@link io.vertx.openapi.validation.ValidatableResponse} must be stored in a specific format depending on the style, location and if they are exploded or not, otherwise the {@link io.vertx.openapi.validation.ResponseValidator} can't validate the response.
+The required format *MUST* exactly look like as described in the JavaDoc of {@link io.vertx.openapi.validation.ResponseValidator}.

--- a/src/main/java/examples/ValidationExamples.java
+++ b/src/main/java/examples/ValidationExamples.java
@@ -13,9 +13,14 @@
 package examples;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.openapi.contract.OpenAPIContract;
 import io.vertx.openapi.validation.RequestValidator;
+import io.vertx.openapi.validation.ResponseValidator;
 import io.vertx.openapi.validation.ValidatableRequest;
+import io.vertx.openapi.validation.ValidatableResponse;
+
+import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
 
 public class ValidationExamples {
 
@@ -58,6 +63,27 @@ public class ValidationExamples {
       validatedRequest.getHeaders(); // returns the header
       // ..
       // ..
+    });
+  }
+
+  private void validatableResponse(Vertx vertx) {
+    OpenAPIContract contract = getContract();
+    ResponseValidator validator = ResponseValidator.create(vertx, contract);
+
+    JsonObject cat = new JsonObject().put("name", "foo");
+    ValidatableResponse response =
+      ValidatableResponse.create(200, cat.toBuffer(), APPLICATION_JSON.toString());
+
+    vertx.createHttpServer().requestHandler(httpServerRequest -> {
+      validator.validate(response, "yourOperationId")
+        .onSuccess(validatedResponse -> {
+          validatedResponse.getBody(); // returns the body
+          validatedResponse.getHeaders(); // returns the header
+          // ..
+          // ..
+          // send back the validated response
+          validatedResponse.send(httpServerRequest.response());
+        });
     });
   }
 }

--- a/src/main/java/io/vertx/openapi/contract/MediaType.java
+++ b/src/main/java/io/vertx/openapi/contract/MediaType.java
@@ -15,6 +15,11 @@ package io.vertx.openapi.contract;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.json.schema.JsonSchema;
 
+import java.util.List;
+
+import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
+import static java.util.Collections.singletonList;
+
 /**
  * This interface represents the most important attributes of an OpenAPI Operation.
  * <br>
@@ -24,6 +29,12 @@ import io.vertx.json.schema.JsonSchema;
  */
 @VertxGen
 public interface MediaType extends OpenAPIObject {
+
+  List<String> SUPPORTED_MEDIA_TYPES = singletonList(APPLICATION_JSON.toString());
+
+  static boolean isMediaTypeSupported(String type) {
+    return SUPPORTED_MEDIA_TYPES.contains(type.toLowerCase());
+  }
 
   /**
    * @return the schema defining the content of the request.

--- a/src/main/java/io/vertx/openapi/contract/Operation.java
+++ b/src/main/java/io/vertx/openapi/contract/Operation.java
@@ -12,6 +12,7 @@
 
 package io.vertx.openapi.contract;
 
+import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.http.HttpMethod;
 
@@ -56,4 +57,18 @@ public interface Operation extends OpenAPIObject {
    * @return request body of the operation, or null if no request body is defined
    */
   RequestBody getRequestBody();
+
+  /**
+   * @return the default response, or null if no default response is defined.
+   */
+  @Nullable
+  Response getDefaultResponse();
+
+  /**
+   * Returns the response to the passed response code or null.
+   *
+   * @param responseCode The related response code
+   * @return The related response, or null.
+   */
+  Response getResponse(int responseCode);
 }

--- a/src/main/java/io/vertx/openapi/contract/RequestBody.java
+++ b/src/main/java/io/vertx/openapi/contract/RequestBody.java
@@ -31,5 +31,9 @@ public interface RequestBody extends OpenAPIObject {
    */
   boolean isRequired();
 
+  /**
+   * @return a map containing descriptions of potential request payloads. The key is a media type or media
+   * type range and the value describes it.
+   */
   Map<String, MediaType> getContent();
 }

--- a/src/main/java/io/vertx/openapi/contract/Response.java
+++ b/src/main/java/io/vertx/openapi/contract/Response.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.contract;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+import java.util.List;
+import java.util.Map;
+
+@VertxGen
+public interface Response extends OpenAPIObject {
+
+  /**
+   * @return the headers of the response.
+   */
+  List<Parameter> getHeaders();
+
+  /**
+   * @return a map containing descriptions of potential response payloads. The key is a media type or media
+   * type range and the value describes it.
+   */
+  Map<String, MediaType> getContent();
+}

--- a/src/main/java/io/vertx/openapi/contract/impl/ResponseImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/ResponseImpl.java
@@ -14,13 +14,18 @@ package io.vertx.openapi.contract.impl;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.openapi.contract.MediaType;
-import io.vertx.openapi.contract.RequestBody;
+import io.vertx.openapi.contract.Parameter;
+import io.vertx.openapi.contract.Response;
 
+import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.vertx.openapi.contract.Location.HEADER;
 import static io.vertx.openapi.contract.MediaType.SUPPORTED_MEDIA_TYPES;
 import static io.vertx.openapi.contract.MediaType.isMediaTypeSupported;
-import static io.vertx.openapi.contract.OpenAPIContractException.createInvalidContract;
 import static io.vertx.openapi.contract.OpenAPIContractException.createUnsupportedFeature;
 import static io.vertx.openapi.impl.Utils.EMPTY_JSON_OBJECT;
 import static java.lang.String.join;
@@ -28,40 +33,46 @@ import static java.util.Collections.unmodifiableMap;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
-public class RequestBodyImpl implements RequestBody {
-  private static final String KEY_REQUIRED = "required";
+public class ResponseImpl implements Response {
+  private static final String KEY_HEADERS = "headers";
+  private static final String KEY_SCHEMA = "schema";
   private static final String KEY_CONTENT = "content";
 
-  private final JsonObject requestBodyModel;
+  private static final Predicate<String> FILTER_CONTENT_TYPE = name -> !name.equalsIgnoreCase(CONTENT_TYPE.toString());
 
-  private final boolean required;
+  private final List<Parameter> headers;
 
   private final Map<String, MediaType> content;
 
-  public RequestBodyImpl(JsonObject requestBodyModel, String operationId) {
-    this.requestBodyModel = requestBodyModel;
-    this.required = requestBodyModel.getBoolean(KEY_REQUIRED, false);
-    JsonObject contentObject = requestBodyModel.getJsonObject(KEY_CONTENT, EMPTY_JSON_OBJECT);
+  private final JsonObject responseModel;
+
+  public ResponseImpl(JsonObject responseModel, String operationId) {
+    this.responseModel = responseModel;
+
+    JsonObject headersObject = responseModel.getJsonObject(KEY_HEADERS, EMPTY_JSON_OBJECT);
+    this.headers = headersObject.fieldNames().stream().filter(FILTER_CONTENT_TYPE).map(name -> {
+      JsonObject headerModel = headersObject.getJsonObject(name).copy().put("name", name).put("in", HEADER.toString());
+      return new ParameterImpl("", headerModel);
+    }).collect(Collectors.toList());
+
+    JsonObject contentObject = responseModel.getJsonObject(KEY_CONTENT, EMPTY_JSON_OBJECT);
     this.content = unmodifiableMap(contentObject.fieldNames().stream()
       .collect(toMap(identity(), key -> new MediaTypeImpl(contentObject.getJsonObject(key)))));
-    if (content.isEmpty()) {
-      String msg =
-        String.format("Operation %s defines a request body without or with empty property \"content\"", operationId);
-      throw createInvalidContract(msg);
-    } else if (content.keySet().stream().anyMatch(type -> !isMediaTypeSupported(type))) {
-      String msgTemplate = "Operation %s defines a request body with an unsupported media type. Supported: %s";
+
+    if (content.keySet().stream().anyMatch(type -> !isMediaTypeSupported(type))) {
+      String msgTemplate = "Operation %s defines a response with an unsupported media type. Supported: %s";
       throw createUnsupportedFeature(String.format(msgTemplate, operationId, join(",", SUPPORTED_MEDIA_TYPES)));
     }
   }
 
   @Override
   public JsonObject getOpenAPIModel() {
-    return requestBodyModel.copy();
+    return responseModel.copy();
   }
 
   @Override
-  public boolean isRequired() {
-    return required;
+  public List<Parameter> getHeaders() {
+    return headers;
   }
 
   @Override

--- a/src/main/java/io/vertx/openapi/validation/RequestUtils.java
+++ b/src/main/java/io/vertx/openapi/validation/RequestUtils.java
@@ -149,7 +149,7 @@ public class RequestUtils {
     return (int) templatePath.subSequence(0, idx).chars().filter(c -> c == '/').count();
   }
 
-  private static String decodeUrl(String encoded) {
+  static String decodeUrl(String encoded) {
     try {
       return encoded == null ? null : URLDecoder.decode(encoded, StandardCharsets.UTF_8.name());
     } catch (Exception e) {

--- a/src/main/java/io/vertx/openapi/validation/RequestValidator.java
+++ b/src/main/java/io/vertx/openapi/validation/RequestValidator.java
@@ -96,7 +96,8 @@ public interface RequestValidator {
   /**
    * Create a new {@link RequestValidator}.
    *
-   * @param vertx the related Vert.x instance
+   * @param vertx    the related Vert.x instance
+   * @param contract the related {@link OpenAPIContract}
    * @return an instance of {@link RequestValidator}.
    */
   static RequestValidator create(Vertx vertx, OpenAPIContract contract) {

--- a/src/main/java/io/vertx/openapi/validation/ResponseParameter.java
+++ b/src/main/java/io/vertx/openapi/validation/ResponseParameter.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen
+public interface ResponseParameter extends Parameter {
+}

--- a/src/main/java/io/vertx/openapi/validation/ResponseValidator.java
+++ b/src/main/java/io/vertx/openapi/validation/ResponseValidator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.openapi.contract.OpenAPIContract;
+import io.vertx.openapi.validation.impl.ResponseValidatorImpl;
+
+/**
+ * The {@link ResponseValidator} requires the {@link ValidatableResponse parameters} in a specific format to be able to
+ * parse and validate them. This is especially true for <i>exploded</i> parameters. The following table shows how the
+ * value of a parameter of a response must be stored in a {@link ValidatableResponse} object. For these examples the key
+ * of those values is always <i>color</i>.
+ * <p></p>
+ * These are the initial values for each type:<br>
+ * <ul>
+ * <li>primitive (string) -> "blue"</li>
+ * <li>array -> ["blue","black","brown"]</li>
+ * <li>object -> { "R": 100, "G": 200, "B": 150 }</li>
+ * </ul>
+ * For header parameters {@link ValidatableRequest#getHeaders()}
+ * <pre>
+ * +--------+---------+-------+-----------+------------------------------------+-------------------------+
+ * | style  | explode | empty | primitive | array                              | object                  |
+ * +--------+---------+-------+-----------+------------------------------------+-------------------------+
+ * | simple | false   |       | blue      | blue,black,brown                   | R,100,G,200,B,150       |
+ * +--------+---------+-------+-----------+------------------------------------+-------------------------+
+ * | simple | true    |       | blue      | blue,black,brown                   | R=100,G=200,B=150       |
+ * +--------+---------+-------+-----------+------------------------------------+-------------------------+
+ * </pre>
+ */
+public interface ResponseValidator {
+
+  /**
+   * Create a new {@link ResponseValidator}.
+   *
+   * @param vertx    the related Vert.x instance
+   * @param contract the related {@link OpenAPIContract}
+   * @return an instance of {@link ResponseValidator}.
+   */
+  static ResponseValidator create(Vertx vertx, OpenAPIContract contract) {
+    return new ResponseValidatorImpl(vertx, contract);
+  }
+
+  /**
+   * Validates the passed response parameters against the operation defined in the related OpenAPI contract.
+   *
+   * @param params      the response parameters to validate.
+   * @param operationId the id of the related operation.
+   * @return A succeeded Future with the parsed and validated response parameters, or a failed Future containing ValidationException.
+   */
+  Future<ValidatedResponse> validate(ValidatableResponse params, String operationId);
+}

--- a/src/main/java/io/vertx/openapi/validation/ValidatableResponse.java
+++ b/src/main/java/io/vertx/openapi/validation/ValidatableResponse.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.openapi.validation.impl.RequestParameterImpl;
+import io.vertx.openapi.validation.impl.ValidatableResponseImpl;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.toMap;
+
+@VertxGen
+public interface ValidatableResponse {
+
+  /**
+   * Creates a new {@link ValidatableResponse} object based on the passed parameters.
+   *
+   * @param statusCode The related status code
+   * @return a {@link ValidatableResponse} object
+   */
+  static ValidatableResponse create(int statusCode) {
+    return create(statusCode, null, null, null);
+  }
+
+  /**
+   * Creates a new {@link ValidatableResponse} object based on the passed parameters.
+   *
+   * @param statusCode The related status code
+   * @param headers    The related headers
+   * @return a {@link ValidatableResponse} object
+   */
+  static ValidatableResponse create(int statusCode, Map<String, String> headers) {
+    return create(statusCode, headers, null, null);
+  }
+
+  /**
+   * Creates a new {@link ValidatableResponse} object based on the passed parameters.
+   *
+   * @param statusCode  The related status code
+   * @param body        The related body
+   * @param contentType The related content type
+   * @return a {@link ValidatableResponse} object
+   * @throws IllegalArgumentException in case body is passed without contentType.
+   */
+  static ValidatableResponse create(int statusCode, Buffer body, String contentType) {
+    return create(statusCode, null, body, contentType);
+  }
+
+  /**
+   * Creates a new {@link ValidatableResponse} object based on the passed parameters.
+   * <p>
+   *
+   * @param statusCode  The related status code
+   * @param headers     The related headers
+   * @param body        The related body
+   * @param contentType The related content type
+   * @return a {@link ValidatableResponse} object
+   * @throws IllegalArgumentException in case body is passed without contentType.
+   */
+  static ValidatableResponse create(int statusCode, Map<String, String> headers, Buffer body, String contentType) {
+    Map<String, ResponseParameter> transformedHeaders =
+      Optional.ofNullable(headers).orElse(emptyMap()).entrySet().stream().collect(toMap(
+        Entry::getKey, entry -> new RequestParameterImpl(entry.getValue())));
+
+    if (body != null && contentType == null) {
+      throw new IllegalArgumentException("When a body is passed, the content type MUST be specified");
+    }
+
+    return new ValidatableResponseImpl(statusCode, transformedHeaders, new RequestParameterImpl(body), contentType);
+  }
+
+  /**
+   * @return the header parameters.
+   */
+  Map<String, ResponseParameter> getHeaders();
+
+  /**
+   * @return the body.
+   */
+  ResponseParameter getBody();
+
+  @Nullable
+  String getContentType();
+
+  int getStatusCode();
+}

--- a/src/main/java/io/vertx/openapi/validation/ValidatedRequest.java
+++ b/src/main/java/io/vertx/openapi/validation/ValidatedRequest.java
@@ -20,6 +20,11 @@ import java.util.Map;
 public interface ValidatedRequest {
 
   /**
+   * @return the cookie parameters.
+   */
+  Map<String, RequestParameter> getCookies();
+
+  /**
    * @return the path parameters.
    */
   Map<String, RequestParameter> getPathParameters();
@@ -28,11 +33,6 @@ public interface ValidatedRequest {
    * @return the query parameters.
    */
   Map<String, RequestParameter> getQuery();
-
-  /**
-   * @return the cookie parameters.
-   */
-  Map<String, RequestParameter> getCookies();
 
   /**
    * @return the header parameters.

--- a/src/main/java/io/vertx/openapi/validation/ValidatedResponse.java
+++ b/src/main/java/io/vertx/openapi/validation/ValidatedResponse.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpServerResponse;
+
+import java.util.Map;
+
+@VertxGen
+public interface ValidatedResponse {
+
+  /**
+   * @return the header parameters.
+   */
+  Map<String, ResponseParameter> getHeaders();
+
+  /**
+   * @return the body.
+   */
+  ResponseParameter getBody();
+
+  /**
+   * Add all parameters from the validated response to the passed {@link HttpServerResponse} and send it.
+   *
+   * @param serverResponse The related response
+   * @return A succeeded Future when the response was sent successfully, otherwise a failed one.
+   */
+  Future<Void> send(HttpServerResponse serverResponse);
+}

--- a/src/main/java/io/vertx/openapi/validation/ValidatorErrorType.java
+++ b/src/main/java/io/vertx/openapi/validation/ValidatorErrorType.java
@@ -17,7 +17,7 @@ import io.vertx.codegen.annotations.VertxGen;
 @VertxGen
 public enum ValidatorErrorType {
   /**
-   * A required parameter was not part of the request
+   * A required parameter was not part of the request or response
    */
   MISSING_REQUIRED_PARAMETER,
 
@@ -44,5 +44,10 @@ public enum ValidatorErrorType {
   /**
    * The request can't get validated due to missing operation information.
    */
-  MISSING_OPERATION
+  MISSING_OPERATION,
+
+  /**
+   * The response can't get validated due to missing response definition for the related status code information.
+   */
+  MISSING_RESPONSE
 }

--- a/src/main/java/io/vertx/openapi/validation/ValidatorException.java
+++ b/src/main/java/io/vertx/openapi/validation/ValidatorException.java
@@ -23,6 +23,7 @@ import static io.vertx.openapi.validation.ValidatorErrorType.INVALID_VALUE;
 import static io.vertx.openapi.validation.ValidatorErrorType.INVALID_VALUE_FORMAT;
 import static io.vertx.openapi.validation.ValidatorErrorType.MISSING_OPERATION;
 import static io.vertx.openapi.validation.ValidatorErrorType.MISSING_REQUIRED_PARAMETER;
+import static io.vertx.openapi.validation.ValidatorErrorType.MISSING_RESPONSE;
 import static io.vertx.openapi.validation.ValidatorErrorType.UNSUPPORTED_VALUE_FORMAT;
 
 public class ValidatorException extends RuntimeException {
@@ -39,7 +40,7 @@ public class ValidatorException extends RuntimeException {
   }
 
   public static ValidatorException createMissingRequiredParameter(Parameter parameter) {
-    String msg = String.format("The related request does not contain the required %s parameter %s",
+    String msg = String.format("The related request / response does not contain the required %s parameter %s",
       parameter.getIn().name().toLowerCase(), parameter.getName());
     return new ValidatorException(msg, MISSING_REQUIRED_PARAMETER);
   }
@@ -70,7 +71,7 @@ public class ValidatorException extends RuntimeException {
   }
 
   public static ValidatorException createInvalidValueBody(JsonSchemaValidationException cause) {
-    String msg = String.format("The value of the request body is invalid. Reason: %s", extractReason(cause));
+    String msg = String.format("The value of the request / response body is invalid. Reason: %s", extractReason(cause));
     return new ValidatorException(msg, INVALID_VALUE, cause);
   }
 
@@ -82,6 +83,11 @@ public class ValidatorException extends RuntimeException {
   public static ValidatorException createOperationNotFound(HttpMethod method, String path) {
     String msg = String.format("No operation found for the request: %s %s", method.name(), path);
     return new ValidatorException(msg, MISSING_OPERATION);
+  }
+
+  public static ValidatorException createResponseNotFound(int statusCode, String operation) {
+    String msg = String.format("No response defined for status code %s in Operation %s", statusCode, operation);
+    return new ValidatorException(msg, MISSING_RESPONSE);
   }
 
   static String extractReason(JsonSchemaValidationException e) {

--- a/src/main/java/io/vertx/openapi/validation/impl/BaseValidator.java
+++ b/src/main/java/io/vertx/openapi/validation/impl/BaseValidator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.openapi.contract.OpenAPIContract;
+import io.vertx.openapi.contract.Operation;
+import io.vertx.openapi.validation.transformer.ApplicationJsonTransformer;
+import io.vertx.openapi.validation.transformer.BodyTransformer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static io.vertx.openapi.validation.ValidatorException.createOperationIdInvalid;
+
+class BaseValidator {
+  protected final Vertx vertx;
+  protected final OpenAPIContract contract;
+  protected final Map<String, BodyTransformer> bodyTransformers;
+
+  public BaseValidator(Vertx vertx, OpenAPIContract contract) {
+    this.vertx = vertx;
+    this.contract = contract;
+
+    bodyTransformers = new HashMap<>();
+    bodyTransformers.put(APPLICATION_JSON.toString(), new ApplicationJsonTransformer());
+  }
+
+  // VisibleForTesting
+  Future<Operation> getOperation(String operationId) {
+    Operation operation = contract.operation(operationId);
+    if (operation == null) {
+      return failedFuture(createOperationIdInvalid(operationId));
+    }
+    return succeededFuture(operation);
+  }
+}

--- a/src/main/java/io/vertx/openapi/validation/impl/RequestParameterImpl.java
+++ b/src/main/java/io/vertx/openapi/validation/impl/RequestParameterImpl.java
@@ -13,10 +13,11 @@
 package io.vertx.openapi.validation.impl;
 
 import io.vertx.openapi.validation.RequestParameter;
+import io.vertx.openapi.validation.ResponseParameter;
 
 import java.util.Objects;
 
-public class RequestParameterImpl implements RequestParameter {
+public class RequestParameterImpl implements RequestParameter, ResponseParameter {
 
   private final Object value;
 

--- a/src/main/java/io/vertx/openapi/validation/impl/ResponseValidatorImpl.java
+++ b/src/main/java/io/vertx/openapi/validation/impl/ResponseValidatorImpl.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.json.schema.JsonSchemaValidationException;
+import io.vertx.json.schema.OutputUnit;
+import io.vertx.openapi.contract.MediaType;
+import io.vertx.openapi.contract.OpenAPIContract;
+import io.vertx.openapi.contract.Parameter;
+import io.vertx.openapi.contract.Response;
+import io.vertx.openapi.validation.ResponseParameter;
+import io.vertx.openapi.validation.ResponseValidator;
+import io.vertx.openapi.validation.ValidatableResponse;
+import io.vertx.openapi.validation.ValidatedResponse;
+import io.vertx.openapi.validation.ValidatorException;
+import io.vertx.openapi.validation.transformer.BodyTransformer;
+import io.vertx.openapi.validation.transformer.ParameterTransformer;
+import io.vertx.openapi.validation.transformer.SimpleTransformer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static io.vertx.openapi.validation.ValidatorErrorType.MISSING_REQUIRED_PARAMETER;
+import static io.vertx.openapi.validation.ValidatorErrorType.UNSUPPORTED_VALUE_FORMAT;
+import static io.vertx.openapi.validation.ValidatorException.createInvalidValue;
+import static io.vertx.openapi.validation.ValidatorException.createInvalidValueBody;
+import static io.vertx.openapi.validation.ValidatorException.createMissingRequiredParameter;
+import static io.vertx.openapi.validation.ValidatorException.createResponseNotFound;
+
+public class ResponseValidatorImpl extends BaseValidator implements ResponseValidator {
+  private static final ParameterTransformer TRANSFORMER = new SimpleTransformer();
+
+  public ResponseValidatorImpl(Vertx vertx, OpenAPIContract contract) {
+    super(vertx, contract);
+  }
+
+  // VisibleForTesting
+  Future<Response> getResponse(ValidatableResponse params, String operationId) {
+    return getOperation(operationId).compose(op -> {
+      Response response = Optional.ofNullable(op.getResponse(params.getStatusCode())).orElse(op.getDefaultResponse());
+      if (response == null) {
+        return failedFuture(createResponseNotFound(params.getStatusCode(), operationId));
+      }
+      return succeededFuture(response);
+    });
+  }
+
+  @Override
+  public Future<ValidatedResponse> validate(ValidatableResponse params, String operationId) {
+    return getResponse(params, operationId).compose(response -> vertx.executeBlocking(p -> {
+      Map<String, ResponseParameter> headers = new HashMap<>(params.getHeaders().size());
+      for (Parameter header : response.getHeaders()) {
+        headers.put(header.getName(), validateParameter(header, params.getHeaders().get(header.getName())));
+      }
+
+      ResponseParameter body = validateBody(response, params);
+      p.complete(new ValidatedResponseImpl(headers, body, params));
+    }));
+  }
+
+  // VisibleForTesting
+  ResponseParameter validateParameter(Parameter parameter, ResponseParameter value) throws ValidatorException {
+    if (value == null || value.isNull()) {
+      if (parameter.isRequired()) {
+        throw createMissingRequiredParameter(parameter);
+      } else {
+        return new RequestParameterImpl(null);
+      }
+    }
+    Object transformedValue = TRANSFORMER.transform(parameter, value.getString());
+
+    OutputUnit result = contract.getSchemaRepository().validator(parameter.getSchema()).validate(transformedValue);
+
+    try {
+      result.checkValidity();
+      return new RequestParameterImpl(transformedValue);
+    } catch (JsonSchemaValidationException e) {
+      throw createInvalidValue(parameter, e);
+    }
+  }
+
+  // VisibleForTesting
+  ResponseParameter validateBody(Response response, ValidatableResponse params) {
+    if (response.getContent().isEmpty()) {
+      return new RequestParameterImpl(null);
+    }
+    if (params.getBody() == null || params.getBody().isEmpty()) {
+      throw new ValidatorException("The related response does not contain the required body.",
+        MISSING_REQUIRED_PARAMETER);
+    }
+
+    String mediaTypeIdentifier = params.getContentType();
+    MediaType mediaType = response.getContent().get(mediaTypeIdentifier);
+    BodyTransformer transformer = bodyTransformers.get(mediaTypeIdentifier);
+    if (transformer == null || mediaType == null) {
+      throw new ValidatorException("The format of the response body is not supported", UNSUPPORTED_VALUE_FORMAT);
+    }
+
+    Object transformedValue = transformer.transform(mediaType, params.getBody().getBuffer());
+    OutputUnit result = contract.getSchemaRepository().validator(mediaType.getSchema()).validate(transformedValue);
+
+    try {
+      result.checkValidity();
+      return new RequestParameterImpl(transformedValue);
+    } catch (JsonSchemaValidationException e) {
+      throw createInvalidValueBody(e);
+    }
+  }
+}

--- a/src/main/java/io/vertx/openapi/validation/impl/ValidatableResponseImpl.java
+++ b/src/main/java/io/vertx/openapi/validation/impl/ValidatableResponseImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation.impl;
+
+import io.vertx.openapi.validation.ResponseParameter;
+import io.vertx.openapi.validation.ValidatableResponse;
+
+import java.util.Map;
+
+public class ValidatableResponseImpl extends ValidatedResponseImpl implements ValidatableResponse {
+
+  private final String contentType;
+
+  private final int statusCode;
+
+  public ValidatableResponseImpl(int statusCode, Map<String, ResponseParameter> headers) {
+    this(statusCode, headers, null, null);
+  }
+
+  public ValidatableResponseImpl(int statusCode, Map<String, ResponseParameter> headers, ResponseParameter body,
+    String contentType) {
+    super(headers, body, null);
+    this.statusCode = statusCode;
+    this.contentType = contentType;
+  }
+
+  @Override
+  public String getContentType() {
+    return contentType;
+  }
+
+  @Override
+  public int getStatusCode() {
+    return statusCode;
+  }
+}

--- a/src/main/java/io/vertx/openapi/validation/impl/ValidatedResponseImpl.java
+++ b/src/main/java/io/vertx/openapi/validation/impl/ValidatedResponseImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.openapi.validation.ResponseParameter;
+import io.vertx.openapi.validation.ValidatableResponse;
+import io.vertx.openapi.validation.ValidatedResponse;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
+
+public class ValidatedResponseImpl implements ValidatedResponse {
+  private final Map<String, ResponseParameter> headers;
+  private final ResponseParameter body;
+  private final ValidatableResponse unvalidated;
+
+  public ValidatedResponseImpl(Map<String, ResponseParameter> headers, ResponseParameter body,
+    ValidatableResponse unvalidated) {
+    this.headers = safeUnmodifiableMap(headers);
+    this.body = body == null ? new RequestParameterImpl(null) : body;
+    this.unvalidated = unvalidated;
+  }
+
+  protected static Map<String, ResponseParameter> safeUnmodifiableMap(Map<String, ResponseParameter> map) {
+    return Collections.unmodifiableMap(map == null ? Collections.emptyMap() : map);
+  }
+
+  @Override
+  public Map<String, ResponseParameter> getHeaders() {
+    return headers;
+  }
+
+  @Override
+  public ResponseParameter getBody() {
+    return body;
+  }
+
+  @Override
+  public Future<Void> send(HttpServerResponse serverResponse) {
+    serverResponse.setStatusCode(unvalidated.getStatusCode());
+
+    for (String header : headers.keySet()) {
+      ResponseParameter headerValue = unvalidated.getHeaders().get(header);
+      if (headerValue != null) {
+        serverResponse.headers().add(header, headerValue.getString());
+      }
+    }
+
+    if (body.isEmpty()) {
+      return serverResponse.send();
+    } else {
+      serverResponse.headers().add(CONTENT_TYPE.toString(), unvalidated.getContentType());
+      return serverResponse.send(unvalidated.getBody().getBuffer());
+    }
+  }
+}

--- a/src/test/java/io/vertx/openapi/contract/impl/OperationImplTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/OperationImplTest.java
@@ -35,10 +35,10 @@ import java.util.stream.Stream;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.vertx.core.http.HttpMethod.GET;
-import static io.vertx.openapi.impl.Utils.EMPTY_JSON_ARRAY;
 import static io.vertx.openapi.contract.ContractErrorType.INVALID_SPEC;
 import static io.vertx.openapi.contract.Location.PATH;
 import static io.vertx.openapi.contract.impl.ParameterImpl.parseParameters;
+import static io.vertx.openapi.impl.Utils.EMPTY_JSON_ARRAY;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -62,7 +62,11 @@ class OperationImplTest {
   private static Stream<Arguments> provideErrorScenarios() {
     return Stream.of(
       Arguments.of("0000_Multiple_Exploded_Form_Parameters_In_Query_With_Content_Object", INVALID_SPEC,
-        "The passed OpenAPI contract is invalid: Found multiple exploded query parameters of style form with type object in operation: showPetById")
+        "The passed OpenAPI contract is invalid: Found multiple exploded query parameters of style form with type object in operation: showPetById"),
+      Arguments.of("0001_No_Responses", INVALID_SPEC,
+        "The passed OpenAPI contract is invalid: No responses were found in operation: getPets"),
+      Arguments.of("0002_Empty_Responses", INVALID_SPEC,
+        "The passed OpenAPI contract is invalid: No responses were found in operation: getPets")
     );
   }
 
@@ -114,6 +118,9 @@ class OperationImplTest {
     assertThat(params).hasSize(1);
     assertThat(params.get(0).getName()).isEqualTo("petId");
     assertThat(params.get(0).getIn()).isEqualTo(PATH);
+
+    assertThat(operation.getDefaultResponse()).isNotNull();
+    assertThat(operation.getResponse(200)).isNotNull();
   }
 
   @Test

--- a/src/test/java/io/vertx/openapi/contract/impl/RequestBodyImplTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/RequestBodyImplTest.java
@@ -68,7 +68,7 @@ class RequestBodyImplTest {
         "The passed OpenAPI contract is invalid: Operation dummyOperation defines a request body without or with empty property \"content\""),
       Arguments.of("0001_RequestBody_With_Empty_Content", INVALID_SPEC,
         "The passed OpenAPI contract is invalid: Operation dummyOperation defines a request body without or with empty property \"content\""),
-      Arguments.of("0002_RequestBody_With_Content_Type_Plain_Text", UNSUPPORTED_FEATURE,
+      Arguments.of("0002_RequestBody_With_Content_Type_Text_Plain", UNSUPPORTED_FEATURE,
         "The passed OpenAPI contract contains a feature that is not supported: Operation dummyOperation defines a request body with an unsupported media type. Supported: application/json")
     );
   }

--- a/src/test/java/io/vertx/openapi/contract/impl/ResponseImplTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/ResponseImplTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.contract.impl;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.json.schema.common.dsl.SchemaType;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.openapi.contract.ContractErrorType;
+import io.vertx.openapi.contract.OpenAPIContractException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
+import static io.vertx.json.schema.common.dsl.SchemaType.INTEGER;
+import static io.vertx.json.schema.common.dsl.SchemaType.STRING;
+import static io.vertx.openapi.ResourceHelper.getRelatedTestResourcePath;
+import static io.vertx.openapi.contract.ContractErrorType.UNSUPPORTED_FEATURE;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(VertxExtension.class)
+class ResponseImplTest {
+  private static final Path RESOURCE_PATH = getRelatedTestResourcePath(ResponseImplTest.class);
+  private static final Path VALID_RESPONSE_JSON = RESOURCE_PATH.resolve("response_valid.json");
+  private static final Path INVALID_RESPONSE_JSON = RESOURCE_PATH.resolve("response_invalid.json");
+
+  private static final String DUMMY_OPERATION_ID = "dummyOperation";
+
+  private static JsonObject validTestData;
+
+  private static JsonObject invalidTestData;
+
+  @BeforeAll
+  static void setUp(Vertx vertx) {
+    validTestData = vertx.fileSystem().readFileBlocking(VALID_RESPONSE_JSON.toString()).toJsonObject();
+    invalidTestData = vertx.fileSystem().readFileBlocking(INVALID_RESPONSE_JSON.toString()).toJsonObject();
+  }
+
+  private static Stream<Arguments> testGetters() {
+    String contentKey = APPLICATION_JSON.toString();
+    return Stream.of(
+      Arguments.of("0000_Test_Getters_No_Headers", 1, contentKey, 0, null),
+      Arguments.of("0001_Test_Getters_With_Headers", 1, contentKey, 1, STRING),
+      Arguments.of("0002_Test_Getters_With_Headers_Ignore_Content_Type_Header", 1, contentKey, 1, INTEGER),
+      Arguments.of("0003_Test_Getters_No_Headers_No_Content", 0, null, 0, null)
+    );
+  }
+
+  private static Stream<Arguments> testExceptions() {
+    return Stream.of(
+      Arguments.of("0000_Response_With_Content_Type_Text_Plain", UNSUPPORTED_FEATURE,
+        "The passed OpenAPI contract contains a feature that is not supported: Operation dummyOperation defines a response with an unsupported media type. Supported: application/json")
+    );
+  }
+
+  @ParameterizedTest(name = "{index} test getters for scenario: {0}")
+  @MethodSource
+  void testGetters(String testId, int contentSize, String contentKey, int headerSize, SchemaType type) {
+    JsonObject responseModel = validTestData.getJsonObject(testId);
+    ResponseImpl response = new ResponseImpl(responseModel, DUMMY_OPERATION_ID);
+
+    assertThat(response.getHeaders()).hasSize(headerSize);
+    if (headerSize > 0) {
+      SchemaType actualType = response.getHeaders().stream().findFirst().get().getSchemaType();
+      assertThat(actualType).isEqualTo(type);
+    }
+
+    assertThat(response.getOpenAPIModel()).isEqualTo(responseModel);
+    assertThat(response.getContent()).hasSize(contentSize);
+    if (contentSize > 0) {
+      assertThat(response.getContent()).containsKey(contentKey);
+    }
+  }
+
+  @ParameterizedTest(name = "{index} should throw an exception for scenario: {0}")
+  @MethodSource
+  void testExceptions(String testId, ContractErrorType type, String msg) {
+    JsonObject response = invalidTestData.getJsonObject(testId);
+    OpenAPIContractException exception =
+      assertThrows(OpenAPIContractException.class, () -> new ResponseImpl(response, DUMMY_OPERATION_ID));
+    assertThat(exception.type()).isEqualTo(type);
+    assertThat(exception).hasMessageThat().isEqualTo(msg);
+  }
+}

--- a/src/test/java/io/vertx/openapi/impl/UtilsTest.java
+++ b/src/test/java/io/vertx/openapi/impl/UtilsTest.java
@@ -59,15 +59,13 @@ class UtilsTest {
   @Test
   public void testNumericYamlKeysAsString(Vertx vertx, VertxTestContext testContext) {
     Utils.readYamlOrJson(vertx, "quirks/test.yaml")
-      .onSuccess(json -> {
-        testContext.verify(() -> {
-          assertThat(json).isNotNull();
-          for (Object key : json.getMap().keySet()) {
-            assertThat(key).isInstanceOf(String.class);
-          }
-          testContext.completeNow();
-        });
-      })
+      .onSuccess(json -> testContext.verify(() -> {
+        assertThat(json).isNotNull();
+        for (Object key : json.getMap().keySet()) {
+          assertThat(key).isInstanceOf(String.class);
+        }
+        testContext.completeNow();
+      }))
       .onFailure(testContext::failNow);
   }
 

--- a/src/test/java/io/vertx/openapi/validation/RequestUtilsTest.java
+++ b/src/test/java/io/vertx/openapi/validation/RequestUtilsTest.java
@@ -157,7 +157,7 @@ class RequestUtilsTest extends HttpServerTestBase {
       assertThat(params.getQuery().get(parameter.getName()).getString()).isEqualTo(expected);
       testContext.completeNow();
     }, mockOperation(parameter), testContext).compose(
-        v -> createRequest(HttpMethod.GET, "?" + query).map(req -> req.send()))
+        v -> createRequest(HttpMethod.GET, "?" + query).map(HttpClientRequest::send))
       .onFailure(testContext::failNow);
   }
 

--- a/src/test/java/io/vertx/openapi/validation/ResponseValidatorTest.java
+++ b/src/test/java/io/vertx/openapi/validation/ResponseValidatorTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation;
+
+import io.vertx.json.schema.SchemaRepository;
+import io.vertx.openapi.contract.OpenAPIContract;
+import io.vertx.openapi.validation.impl.ResponseValidatorImpl;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ResponseValidatorTest {
+
+  @Test
+  void testCreate() {
+    OpenAPIContract contract = mock(OpenAPIContract.class);
+    when(contract.getSchemaRepository()).thenReturn(mock(SchemaRepository.class));
+    assertThat(ResponseValidator.create(null, contract)).isInstanceOf(ResponseValidatorImpl.class);
+  }
+}

--- a/src/test/java/io/vertx/openapi/validation/ValidatableResponseTest.java
+++ b/src/test/java/io/vertx/openapi/validation/ValidatableResponseTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation;
+
+import com.google.common.collect.ImmutableMap;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ValidatableResponseTest {
+
+  private final int dummyStatusCode = 1337;
+
+  private final Map<String, String> dummyHeaders = ImmutableMap.of("foo", "bar");
+
+  private final Buffer dummyBody = new JsonObject().put("name", "foo").toBuffer();
+
+  private final String dummyContentType = HttpHeaderValues.APPLICATION_JSON.toString();
+
+  @Test
+  void testCreateStatusCode() {
+    ValidatableResponse response = ValidatableResponse.create(dummyStatusCode);
+    assertThat(response.getStatusCode()).isEqualTo(dummyStatusCode);
+    assertThat(response.getHeaders()).isEmpty();
+    assertThat(response.getContentType()).isNull();
+    assertThat(response.getBody().get()).isNull();
+  }
+
+  @Test
+  void testCreateStatusCodeAndHeaders() {
+    ValidatableResponse response = ValidatableResponse.create(dummyStatusCode, dummyHeaders);
+    assertThat(response.getStatusCode()).isEqualTo(dummyStatusCode);
+    assertThat(response.getHeaders()).hasSize(1);
+    assertThat(response.getContentType()).isNull();
+    assertThat(response.getBody().get()).isNull();
+  }
+
+  @Test
+  void testCreateStatusCodeAndBody() {
+    ValidatableResponse response = ValidatableResponse.create(dummyStatusCode, dummyBody, dummyContentType);
+    assertThat(response.getStatusCode()).isEqualTo(dummyStatusCode);
+    assertThat(response.getHeaders()).isEmpty();
+    assertThat(response.getBody().get()).isEqualTo(dummyBody);
+    assertThat(response.getContentType()).isEqualTo(dummyContentType);
+  }
+
+  @Test
+  void testCreate() {
+    ValidatableResponse response =
+      ValidatableResponse.create(dummyStatusCode, dummyHeaders, dummyBody, dummyContentType);
+    assertThat(response.getStatusCode()).isEqualTo(dummyStatusCode);
+    assertThat(response.getHeaders()).hasSize(1);
+    assertThat(response.getBody().get()).isEqualTo(dummyBody);
+    assertThat(response.getContentType()).isEqualTo(dummyContentType);
+  }
+
+  @Test
+  void testCreateThrows() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+      () -> ValidatableResponse.create(dummyStatusCode, dummyHeaders, dummyBody, null));
+    assertThat(exception).hasMessageThat().isEqualTo("When a body is passed, the content type MUST be specified");
+  }
+}

--- a/src/test/java/io/vertx/openapi/validation/ValidatorExceptionTest.java
+++ b/src/test/java/io/vertx/openapi/validation/ValidatorExceptionTest.java
@@ -31,7 +31,7 @@ class ValidatorExceptionTest {
   @Test
   void testCreateMissingRequiredParameter() {
     ValidatorException exception = ValidatorException.createMissingRequiredParameter(DUMMY_PARAMETER);
-    String expectedMsg = "The related request does not contain the required path parameter dummy";
+    String expectedMsg = "The related request / response does not contain the required path parameter dummy";
     assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);
     assertThat(exception.type()).isEqualTo(ValidatorErrorType.MISSING_REQUIRED_PARAMETER);
   }
@@ -74,5 +74,13 @@ class ValidatorExceptionTest {
     String expectedMsg = "No operation found for the request: GET /my/path";
     assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);
     assertThat(exception.type()).isEqualTo(ValidatorErrorType.MISSING_OPERATION);
+  }
+
+  @Test
+  void testCreateResponseNotFound() {
+    ValidatorException exception = ValidatorException.createResponseNotFound(1337, "getPets");
+    String expectedMsg = "No response defined for status code 1337 in Operation getPets";
+    assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);
+    assertThat(exception.type()).isEqualTo(ValidatorErrorType.MISSING_RESPONSE);
   }
 }

--- a/src/test/java/io/vertx/openapi/validation/impl/BaseValidatorTest.java
+++ b/src/test/java/io/vertx/openapi/validation/impl/BaseValidatorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation.impl;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.openapi.contract.OpenAPIContract;
+import io.vertx.openapi.validation.ValidatorException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.vertx.openapi.ResourceHelper.TEST_RESOURCE_PATH;
+import static org.mockito.Mockito.spy;
+
+@ExtendWith(VertxExtension.class)
+class BaseValidatorTest {
+  private BaseValidator validator;
+
+  private OpenAPIContract contractSpy;
+
+  @BeforeEach
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void initializeContract(Vertx vertx, VertxTestContext testContext) {
+    Path contractFile = TEST_RESOURCE_PATH.resolve("v3.1").resolve("petstore.json");
+    JsonObject contract = vertx.fileSystem().readFileBlocking(contractFile.toString()).toJsonObject();
+    OpenAPIContract.from(vertx, contract).onSuccess(c -> testContext.verify(() -> {
+      this.contractSpy = spy(c);
+      this.validator = new BaseValidator(vertx, contractSpy);
+      testContext.completeNow();
+    })).onFailure(testContext::failNow);
+  }
+
+  @Test
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void testGetOperation(VertxTestContext testContext) {
+    validator.getOperation("invalidId").onFailure(t -> testContext.verify(() -> {
+      assertThat(t).isInstanceOf(ValidatorException.class);
+      assertThat(t).hasMessageThat().isEqualTo("Invalid OperationId: invalidId");
+      testContext.completeNow();
+    })).onSuccess(v -> testContext.failNow("Test expects a failure"));
+  }
+}

--- a/src/test/java/io/vertx/openapi/validation/impl/ResponseValidatorImplTest.java
+++ b/src/test/java/io/vertx/openapi/validation/impl/ResponseValidatorImplTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation.impl;
+
+import com.google.common.collect.ImmutableMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.json.schema.JsonSchema;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.openapi.contract.MediaType;
+import io.vertx.openapi.contract.OpenAPIContract;
+import io.vertx.openapi.contract.Operation;
+import io.vertx.openapi.contract.Parameter;
+import io.vertx.openapi.contract.Response;
+import io.vertx.openapi.validation.ResponseParameter;
+import io.vertx.openapi.validation.ValidatableResponse;
+import io.vertx.openapi.validation.ValidatorException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
+import static io.netty.handler.codec.http.HttpHeaderValues.TEXT_PLAIN;
+import static io.vertx.json.schema.common.dsl.Schemas.intSchema;
+import static io.vertx.json.schema.common.dsl.Schemas.objectSchema;
+import static io.vertx.json.schema.common.dsl.Schemas.stringSchema;
+import static io.vertx.openapi.MockHelper.mockParameter;
+import static io.vertx.openapi.ResourceHelper.TEST_RESOURCE_PATH;
+import static io.vertx.openapi.contract.Location.HEADER;
+import static io.vertx.openapi.contract.Style.SIMPLE;
+import static io.vertx.openapi.validation.ValidatorErrorType.INVALID_VALUE;
+import static io.vertx.openapi.validation.ValidatorErrorType.MISSING_REQUIRED_PARAMETER;
+import static io.vertx.openapi.validation.ValidatorErrorType.UNSUPPORTED_VALUE_FORMAT;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+class ResponseValidatorImplTest {
+  private ResponseValidatorImpl validator;
+  private OpenAPIContract contractSpy;
+
+  private static Parameter buildParam(String name, JsonObject schema, boolean required) {
+    return mockParameter(name, HEADER, SIMPLE, false, JsonSchema.of(schema), required);
+  }
+
+  private static Stream<Arguments> provideNullRequestParameters() {
+    return Stream.of(
+      Arguments.of("RequestParameter is null", null),
+      Arguments.of("Object in RequestParameter is null", new RequestParameterImpl(null))
+    );
+  }
+
+  private static Response mockResponse() {
+    MediaType mockedMediaType = mock(MediaType.class);
+    when(mockedMediaType.getSchema()).thenReturn(JsonSchema.of(objectSchema().toJson()));
+
+    Response mockedResponse = mock(Response.class);
+    when(mockedResponse.getContent()).thenReturn(ImmutableMap.of(APPLICATION_JSON.toString(), mockedMediaType));
+
+    return mockedResponse;
+  }
+
+  @BeforeEach
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void initializeContract(Vertx vertx, VertxTestContext testContext) {
+    Path contractFile = TEST_RESOURCE_PATH.resolve("v3.1").resolve("petstore.json");
+    JsonObject contract = vertx.fileSystem().readFileBlocking(contractFile.toString()).toJsonObject();
+    OpenAPIContract.from(vertx, contract).onSuccess(c -> {
+      this.contractSpy = spy(c);
+      this.validator = new ResponseValidatorImpl(vertx, contractSpy);
+      testContext.completeNow();
+    }).onFailure(testContext::failNow);
+  }
+
+  @Test
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void testValidate(VertxTestContext testContext) {
+    Map<String, String> headers = ImmutableMap.of("x-next", "foo", "ignore", "this");
+
+    JsonArray body = new JsonArray().add(new JsonObject().put("id", 1337).put("name", "foo"));
+
+    ValidatableResponse validatableResponse =
+      ValidatableResponse.create(200, headers, body.toBuffer(), APPLICATION_JSON.toString());
+
+    validator.validate(validatableResponse, "listPets")
+      .onComplete(testContext.succeeding(validated -> testContext.verify(() -> {
+        assertThat(validated.getBody().getJsonArray()).isEqualTo(body);
+        assertThat(validated.getHeaders()).hasSize(1);
+        assertThat(validated.getHeaders().get("x-next").getString()).isEqualTo("foo");
+        testContext.completeNow();
+      })));
+  }
+
+  @Test
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void testGetResponseThrowResponseNotFound(VertxTestContext testContext) {
+    String operationId = "isMocked";
+    Operation mockedOperation = mock(Operation.class);
+    when(mockedOperation.getDefaultResponse()).thenReturn(null);
+    when(mockedOperation.getResponse(anyInt())).thenReturn(null);
+    when(contractSpy.operation(operationId)).thenReturn(mockedOperation);
+
+    validator.getResponse(ValidatableResponse.create(1337), operationId).onFailure(t -> testContext.verify(() -> {
+      assertThat(t).isInstanceOf(ValidatorException.class);
+      assertThat(t).hasMessageThat().isEqualTo("No response defined for status code 1337 in Operation isMocked");
+      testContext.completeNow();
+    })).onSuccess(v -> testContext.failNow("Test expects a failure"));
+  }
+
+  @Test
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void testGetResponse(VertxTestContext testContext) {
+    String operationId = "isMocked";
+
+    Response mockedResponse = mock(Response.class);
+    Response mockedDefaultResponse = mock(Response.class);
+
+    Operation mockedOperation = mock(Operation.class);
+    when(mockedOperation.getDefaultResponse()).thenReturn(mockedDefaultResponse);
+    when(mockedOperation.getResponse(1337)).thenReturn(mockedResponse);
+    when(contractSpy.operation(operationId)).thenReturn(mockedOperation);
+
+    Checkpoint cp = testContext.checkpoint(2);
+
+    validator.getResponse(ValidatableResponse.create(1337), operationId)
+      .onComplete(testContext.succeeding(resp -> testContext.verify(() -> {
+        assertThat(resp).isEqualTo(mockedResponse);
+        cp.flag();
+      })));
+    validator.getResponse(ValidatableResponse.create(0), operationId)
+      .onComplete(testContext.succeeding(resp -> testContext.verify(() -> {
+        assertThat(resp).isEqualTo(mockedDefaultResponse);
+        cp.flag();
+      })));
+  }
+
+  @Test
+  void testValidateParameter() {
+    Parameter param = buildParam("p1", intSchema().toJson(), true);
+    ResponseParameter validated = validator.validateParameter(param, new RequestParameterImpl("5"));
+    assertThat(validated.getInteger()).isEqualTo(5);
+  }
+
+  @Test
+  void testValidateParameterThrowInvalidValue() {
+    Parameter param = buildParam("p1", stringSchema().toJson(), false);
+    ValidatorException exception =
+      assertThrows(ValidatorException.class, () -> validator.validateParameter(param, new RequestParameterImpl("3")));
+    assertThat(exception.type()).isEqualTo(INVALID_VALUE);
+    String reason = "Instance type number is invalid. Expected string";
+    String expectedMsg =
+      "The value of header parameter p1 is invalid. Reason: " + reason;
+    assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);
+  }
+
+  @ParameterizedTest(name = "{index} Throw error when required param is missing: {0}")
+  @MethodSource("provideNullRequestParameters")
+  void testValidateParameterThrowRequired(String scenario, ResponseParameter value) {
+    Parameter param = buildParam("p1", intSchema().toJson(), true);
+    ValidatorException exception =
+      assertThrows(ValidatorException.class, () -> validator.validateParameter(param, value));
+    String expectedMsg = "The related request / response does not contain the required header parameter p1";
+    assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);
+  }
+
+  @ParameterizedTest(name = "{index} Return empty ResponseParameter when param is missing but not required: {0}")
+  @MethodSource("provideNullRequestParameters")
+  void testValidateParameterValueNullNotRequired(String scenario, ResponseParameter value) {
+    Parameter param = buildParam("p1", intSchema().toJson(), false);
+    ResponseParameter validated = validator.validateParameter(param, value);
+    assertThat(validated.isNull()).isTrue();
+  }
+
+  @Test
+  void testValidateBodyNoContent() {
+    Response mockedResponse = mock(Response.class);
+    when(mockedResponse.getContent()).thenReturn(Collections.emptyMap());
+    ResponseParameter validated = validator.validateBody(mockedResponse, null);
+    assertThat(validated.isNull()).isTrue();
+  }
+
+  @ParameterizedTest(name = "{index} If body is required, validateBody should throw an error if {0}")
+  @MethodSource("provideNullRequestParameters")
+  void testValidateBodyRequiredButNullOrEmpty(String scenario, ResponseParameter parameter) {
+    Response mockedResponse = mockResponse();
+    ValidatableResponse mockedValidatableResponse = mock(ValidatableResponse.class);
+    when(mockedValidatableResponse.getBody()).thenReturn(parameter);
+
+    ValidatorException exceptionEmpty =
+      assertThrows(ValidatorException.class,
+        () -> validator.validateBody(mockedResponse, mockedValidatableResponse));
+    assertThat(exceptionEmpty.type()).isEqualTo(MISSING_REQUIRED_PARAMETER);
+    String expectedMsg = "The related response does not contain the required body.";
+    assertThat(exceptionEmpty).hasMessageThat().isEqualTo(expectedMsg);
+  }
+
+  @ParameterizedTest(name = "validateBody should throw an error if MediaType or Transformer is null")
+  @ValueSource(strings = {"text/plain", "foo/bar"})
+  void testValidateBodyMediaTypeOrTransformerNull(String contentType) {
+    Response mockedResponse = mock(Response.class);
+    when(mockedResponse.getContent()).thenReturn(ImmutableMap.of(TEXT_PLAIN.toString(), mock(MediaType.class)));
+
+    ValidatableResponse mockedValidatableResponse = mock(ValidatableResponse.class);
+    when(mockedValidatableResponse.getContentType()).thenReturn(contentType);
+    when(mockedValidatableResponse.getBody()).thenReturn(new RequestParameterImpl("foo"));
+
+    ValidatorException exceptionEmpty =
+      assertThrows(ValidatorException.class,
+        () -> validator.validateBody(mockedResponse, mockedValidatableResponse));
+    assertThat(exceptionEmpty.type()).isEqualTo(UNSUPPORTED_VALUE_FORMAT);
+    String expectedMsg = "The format of the response body is not supported";
+    assertThat(exceptionEmpty).hasMessageThat().isEqualTo(expectedMsg);
+  }
+
+  @Test
+  void testValidateBodyThrowInvalidValue() {
+    Response mockedResponse = mockResponse();
+    ValidatableResponse mockedValidatableResponse = mock(ValidatableResponse.class);
+    when(mockedValidatableResponse.getBody()).thenReturn(new RequestParameterImpl(Buffer.buffer("3")));
+    when(mockedValidatableResponse.getContentType()).thenReturn(APPLICATION_JSON.toString());
+
+    ValidatorException exception =
+      assertThrows(ValidatorException.class, () -> validator.validateBody(mockedResponse, mockedValidatableResponse));
+    assertThat(exception.type()).isEqualTo(INVALID_VALUE);
+    String reason = "Instance type number is invalid. Expected object";
+    String expectedMsg =
+      "The value of the request / response body is invalid. Reason: " + reason;
+    assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);
+  }
+
+  @Test
+  void testValidateBody() {
+    JsonObject body = new JsonObject().put("foo", "bar");
+
+    Response mockedResponse = mockResponse();
+    ValidatableResponse mockedValidatableResponse = mock(ValidatableResponse.class);
+    when(mockedValidatableResponse.getBody()).thenReturn(new RequestParameterImpl(body.toBuffer()));
+    when(mockedValidatableResponse.getContentType()).thenReturn(APPLICATION_JSON.toString());
+
+    ResponseParameter validated = validator.validateBody(mockedResponse, mockedValidatableResponse);
+    assertThat(validated.getJsonObject()).isEqualTo(body);
+  }
+}

--- a/src/test/java/io/vertx/openapi/validation/impl/ValidatableResponseImplTest.java
+++ b/src/test/java/io/vertx/openapi/validation/impl/ValidatableResponseImplTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation.impl;
+
+import com.google.common.collect.ImmutableMap;
+import io.vertx.openapi.validation.ResponseParameter;
+import io.vertx.openapi.validation.ValidatableResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
+
+class ValidatableResponseImplTest {
+
+  @Test
+  void testGetters() {
+    Map<String, ResponseParameter> headers = ImmutableMap.of("param1", new RequestParameterImpl("Param1"));
+    ResponseParameter body = new RequestParameterImpl("param5");
+    String contentType = APPLICATION_JSON.toString();
+    int statusCode = 1337;
+
+    ValidatableResponse response = new ValidatableResponseImpl(statusCode, headers, body, contentType);
+    assertThat(response.getHeaders()).containsExactlyEntriesIn(headers);
+    assertThat(response.getBody()).isEqualTo(body);
+    assertThat(response.getContentType()).isEqualTo(contentType);
+    assertThat(response.getStatusCode()).isEqualTo(statusCode);
+
+    ValidatableResponse responseNullValues = new ValidatableResponseImpl(statusCode, null);
+    assertThat(responseNullValues.getHeaders()).isEmpty();
+    assertThat(responseNullValues.getBody().isEmpty()).isTrue();
+    assertThat(responseNullValues.getContentType()).isNull();
+    assertThat(response.getStatusCode()).isEqualTo(statusCode);
+  }
+}

--- a/src/test/java/io/vertx/openapi/validation/impl/ValidatedResponseImplTest.java
+++ b/src/test/java/io/vertx/openapi/validation/impl/ValidatedResponseImplTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation.impl;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.openapi.contract.OpenAPIContract;
+import io.vertx.openapi.test.base.HttpServerTestBase;
+import io.vertx.openapi.validation.ResponseParameter;
+import io.vertx.openapi.validation.ResponseValidator;
+import io.vertx.openapi.validation.ValidatableResponse;
+import io.vertx.openapi.validation.ValidatedResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
+import static io.vertx.openapi.ResourceHelper.TEST_RESOURCE_PATH;
+
+class ValidatedResponseImplTest extends HttpServerTestBase {
+
+  private ResponseValidator responseValidator;
+
+  @BeforeEach
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void initializeContract(Vertx vertx, VertxTestContext testContext) {
+    Path contractFile = TEST_RESOURCE_PATH.resolve("v3.1").resolve("petstore.json");
+    JsonObject contract = vertx.fileSystem().readFileBlocking(contractFile.toString()).toJsonObject();
+    OpenAPIContract.from(vertx, contract).onSuccess(c -> {
+      responseValidator = ResponseValidator.create(vertx, c);
+      testContext.completeNow();
+    }).onFailure(testContext::failNow);
+  }
+
+  @BeforeEach
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void initializeContract(Vertx vertx) {
+    Path contractFile = TEST_RESOURCE_PATH.resolve("v3.1").resolve("petstore.json");
+    JsonObject contract = vertx.fileSystem().readFileBlocking(contractFile.toString()).toJsonObject();
+    OpenAPIContract.from(vertx, contract);
+  }
+
+  @Test
+  void testGetters() {
+    Map<String, ResponseParameter> headers = ImmutableMap.of("param1", new RequestParameterImpl("Param1"));
+    ResponseParameter body = new RequestParameterImpl("param5");
+
+    ValidatedResponse request = new ValidatedResponseImpl(headers, body, null);
+    assertThat(request.getHeaders()).containsExactlyEntriesIn(headers);
+    assertThat(request.getBody()).isEqualTo(body);
+  }
+
+  Future<?> verifyResponse(int statusCode, Buffer body, Map<String, String> headers, VertxTestContext testContext) {
+    return createRequest(HttpMethod.GET, "/does_not_matter").compose(HttpClientRequest::send)
+      .compose(response -> response.body().onComplete(testContext.succeeding(receivedBody -> testContext.verify(() -> {
+        assertThat(response.statusCode()).isEqualTo(statusCode);
+        assertThat(receivedBody).isEqualTo(body);
+        assertThat(response.headers().size()).isEqualTo(headers.size());
+        headers.forEach((k, v) -> assertThat(response.headers().get(k)).isEqualTo(v));
+        testContext.completeNow();
+      }))));
+  }
+
+  @Test
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void testSendNoBody(VertxTestContext testContext) {
+    Map<String, String> headersExpected = ImmutableMap.of(CONTENT_LENGTH.toString(), "0");
+    createServer(request -> {
+      responseValidator.validate(ValidatableResponse.create(201), "createPets")
+        .compose(validatedResponse -> validatedResponse.send(request.response())).onFailure(testContext::failNow);
+    }).compose(v -> verifyResponse(201, Buffer.buffer(), headersExpected, testContext));
+  }
+
+  private Map<String, String> buildHeaders(Buffer body) {
+    return Maps.newHashMap(ImmutableMap.of(CONTENT_TYPE.toString(), APPLICATION_JSON.toString(),
+      CONTENT_LENGTH.toString(), "" + body.length()));
+  }
+
+  @Test
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void testSendWithBody(VertxTestContext testContext) {
+    Buffer cat = new JsonObject().put("id", 1337).put("name", "foo").toBuffer();
+    createServer(request -> {
+      ValidatableResponse vr = ValidatableResponse.create(200, cat, APPLICATION_JSON.toString());
+      responseValidator.validate(vr, "showPetById")
+        .compose(validatedResponse -> validatedResponse.send(request.response())).onFailure(testContext::failNow);
+    }).compose(v -> verifyResponse(200, cat, buildHeaders(cat), testContext));
+  }
+
+  @Test
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void testSendWithHeaders(VertxTestContext testContext) {
+    Buffer cats = new JsonArray().add(new JsonObject().put("id", 1337).put("name", "foo")).toBuffer();
+    Map<String, String> headersExpected = buildHeaders(cats);
+    headersExpected.put("x-next", "foo");
+
+    createServer(request -> {
+      Map<String, String> headers = ImmutableMap.of("x-next", "foo");
+      ValidatableResponse vr = ValidatableResponse.create(200, headers, cats, APPLICATION_JSON.toString());
+      responseValidator.validate(vr, "listPets")
+        .compose(validatedResponse -> validatedResponse.send(request.response())).onFailure(testContext::failNow);
+    }).compose(v -> verifyResponse(200, cats, headersExpected, testContext));
+  }
+}

--- a/src/test/resources/io/vertx/openapi/contract/impl/operation_invalid.json
+++ b/src/test/resources/io/vertx/openapi/contract/impl/operation_invalid.json
@@ -31,5 +31,21 @@
         }
       ]
     }
+  },
+  "0001_No_Responses": {
+    "path": "/pets",
+    "method": "get",
+    "operationModel": {
+      "operationId": "getPets"
+    }
+  },
+  "0002_Empty_Responses": {
+    "path": "/pets",
+    "method": "get",
+    "operationModel": {
+      "operationId": "getPets",
+      "responses": {
+      }
+    }
   }
 }

--- a/src/test/resources/io/vertx/openapi/contract/impl/operation_valid.json
+++ b/src/test/resources/io/vertx/openapi/contract/impl/operation_valid.json
@@ -17,7 +17,29 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "responses": {
+        "default": {
+          "description": "unexpected error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "200": {
+          "description": "unexpected error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "0001_Filter_Path_Parameters": {
@@ -50,7 +72,19 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "responses": {
+        "default": {
+          "description": "unexpected error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "0002_Do_Not_Filter_Path_Parameters": {
@@ -83,7 +117,19 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "responses": {
+        "default": {
+          "description": "unexpected error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "0003_Test_RequestBody": {
@@ -102,6 +148,18 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Pet"
+            }
+          }
+        }
+      },
+      "responses": {
+        "default": {
+          "description": "unexpected error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
             }
           }
         }

--- a/src/test/resources/io/vertx/openapi/contract/impl/path_valid.json
+++ b/src/test/resources/io/vertx/openapi/contract/impl/path_valid.json
@@ -17,7 +17,19 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "responses": {
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
       },
       "parameters": [
         {

--- a/src/test/resources/io/vertx/openapi/contract/impl/requestBody_invalid.json
+++ b/src/test/resources/io/vertx/openapi/contract/impl/requestBody_invalid.json
@@ -5,9 +5,9 @@
     "content": {
     }
   },
-  "0002_RequestBody_With_Content_Type_Plain_Text": {
+  "0002_RequestBody_With_Content_Type_Text_Plain": {
     "content": {
-      "plain/text": {
+      "text/plain": {
         "schema": {
           "type": "string"
         }

--- a/src/test/resources/io/vertx/openapi/contract/impl/response_invalid.json
+++ b/src/test/resources/io/vertx/openapi/contract/impl/response_invalid.json
@@ -1,0 +1,11 @@
+{
+  "0000_Response_With_Content_Type_Text_Plain": {
+    "content": {
+      "text/plain": {
+        "schema": {
+          "type": "object"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/io/vertx/openapi/contract/impl/response_valid.json
+++ b/src/test/resources/io/vertx/openapi/contract/impl/response_valid.json
@@ -1,0 +1,50 @@
+{
+  "0000_Test_Getters_No_Headers": {
+    "content": {
+      "application/json": {
+        "schema": {
+          "type": "object"
+        }
+      }
+    }
+  },
+  "0001_Test_Getters_With_Headers": {
+    "headers": {
+      "myHeader": {
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "content": {
+      "application/json": {
+        "schema": {
+          "type": "object"
+        }
+      }
+    }
+  },
+  "0002_Test_Getters_With_Headers_Ignore_Content_Type_Header": {
+    "headers": {
+      "myHeader": {
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "Content-Type": {
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "content": {
+      "application/json": {
+        "schema": {
+          "type": "object"
+        }
+      }
+    }
+  },
+  "0003_Test_Getters_No_Headers_No_Content": {
+  }
+}


### PR DESCRIPTION
Motivation:

With this change it is possible to verify a response based on the related OpenAPI contract.

