### PR TITLE
feat: use checkValidity() method in contract validation

### DIFF
--- a/src/test/java/io/vertx/openapi/contract/OpenAPIContractTest.java
+++ b/src/test/java/io/vertx/openapi/contract/OpenAPIContractTest.java
@@ -16,7 +16,7 @@ import com.google.common.collect.ImmutableMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.json.schema.ValidationException;
+import io.vertx.json.schema.JsonSchemaValidationException;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -107,7 +107,7 @@ class OpenAPIContractTest {
     OpenAPIContract.from(vertx, invalidContractJson).onComplete(testContext.failing(t -> testContext.verify(() -> {
       assertThat(t).isInstanceOf(OpenAPIContractException.class);
       assertThat(t).hasMessageThat().isEqualTo("The passed OpenAPI contract is invalid.");
-      assertThat(t).hasCauseThat().isInstanceOf(ValidationException.class);
+      assertThat(t).hasCauseThat().isInstanceOf(JsonSchemaValidationException.class);
       testContext.completeNow();
     })));
   }


### PR DESCRIPTION
Motivation:

By using the new checkValidity() method in the contract validation, we will get a JsonSchemaValidationException. This JsonSchemaValidationException can then be passed a cause to the OpenAPIContractException.
