### PR TITLE
feat: support base path

### DIFF
--- a/src/main/java/io/vertx/openapi/contract/OpenAPIContract.java
+++ b/src/main/java/io/vertx/openapi/contract/OpenAPIContract.java
@@ -47,7 +47,7 @@ public interface OpenAPIContract {
    * @return A succeeded {@link Future} holding an {@link OpenAPIContract} instance, otherwise a failed {@link Future}.
    */
   static Future<OpenAPIContract> from(Vertx vertx, String unresolvedContractPath) {
-    return readYamlOrJson(vertx, unresolvedContractPath).compose(path -> from(vertx, path, emptyMap()));
+    return readYamlOrJson(vertx, unresolvedContractPath).compose(json -> from(vertx, json));
   }
 
   /**
@@ -174,6 +174,11 @@ public interface OpenAPIContract {
    * @return the {@link SchemaRepository} to validate against.
    */
   SchemaRepository getSchemaRepository();
+
+  /**
+   * @return the servers of the contract.
+   */
+  List<Server> getServers();
 
   /**
    * Finds the related {@link Path} object based on the passed url path.

--- a/src/main/java/io/vertx/openapi/contract/Operation.java
+++ b/src/main/java/io/vertx/openapi/contract/Operation.java
@@ -44,6 +44,11 @@ public interface Operation extends OpenAPIObject {
   String getOpenAPIPath();
 
   /**
+   * @return absolute path in OpenAPI style
+   */
+  String getAbsoluteOpenAPIPath();
+
+  /**
    * @return tags of this operation
    */
   List<String> getTags();

--- a/src/main/java/io/vertx/openapi/contract/Server.java
+++ b/src/main/java/io/vertx/openapi/contract/Server.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.contract;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * This interface represents the most important attributes of an OpenAPI Server.
+ * <br>
+ * <a href="https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#server-Object">Server V3.1</a>
+ * <br>
+ * <a href="https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-Object">Server V3.0</a>
+ */
+@VertxGen
+public interface Server extends OpenAPIObject {
+
+  /**
+   * @return the URL of the related server
+   */
+  String getURL();
+
+  /**
+   * The base path is used to indicate that the location where the OpenAPI contract is served is different
+   * from the path specified in the OpenAPI contract.
+   *
+   * @return the related base path.
+   */
+  String getBasePath();
+}

--- a/src/main/java/io/vertx/openapi/contract/impl/OperationImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/OperationImpl.java
@@ -58,8 +58,11 @@ public class OperationImpl implements Operation {
   private final List<String> tags;
   private final Response defaultResponse;
   private final Map<Integer, Response> responses;
+  private final String absolutePath;
 
-  public OperationImpl(String path, HttpMethod method, JsonObject operationModel, List<Parameter> pathParameters) {
+  public OperationImpl(String absolutePath, String path, HttpMethod method, JsonObject operationModel,
+    List<Parameter> pathParameters) {
+    this.absolutePath = absolutePath;
     this.operationId = operationModel.getString(KEY_OPERATION_ID);
     this.method = method;
     this.path = path;
@@ -133,6 +136,11 @@ public class OperationImpl implements Operation {
   @Override
   public String getOpenAPIPath() {
     return path;
+  }
+
+  @Override
+  public String getAbsoluteOpenAPIPath() {
+    return absolutePath;
   }
 
   @Override

--- a/src/main/java/io/vertx/openapi/contract/impl/PathFinder.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/PathFinder.java
@@ -34,7 +34,7 @@ class PathFinder {
    * <p>
    * [2, (/v1/users, /v1/friends) ]
    */
-  private final Map<Integer, List<Path>> segmentsWithoutTemplating = new HashMap<>();
+  private final Map<Integer, List<PathImpl>> segmentsWithoutTemplating = new HashMap<>();
 
   /**
    * /v1/user/{userid}/name
@@ -51,9 +51,9 @@ class PathFinder {
    */
   private final Map<Integer, Map<Path, String[]>> segmentsWithTemplating = new HashMap<>();
 
-  public PathFinder(List<Path> paths) {
-    for (Path path : paths) {
-      String[] segments = path.getName().substring(1).split("/");
+  public PathFinder(List<PathImpl> paths) {
+    for (PathImpl path : paths) {
+      String[] segments = path.getAbsolutePath().substring(1).split("/");
       if (path.getName().contains("{")) {
         segmentsWithTemplating.computeIfAbsent(segments.length, i -> new HashMap<>()).put(path, segments);
       } else {
@@ -65,8 +65,8 @@ class PathFinder {
   public Path findPath(String path) {
     String[] segments = path.substring(1).split("/");
 
-    for (Path p : segmentsWithoutTemplating.getOrDefault(segments.length, emptyList())) {
-      if (p.getName().equals(path)) {
+    for (PathImpl p : segmentsWithoutTemplating.getOrDefault(segments.length, emptyList())) {
+      if (p.getAbsolutePath().equals(path)) {
         return p;
       }
     }

--- a/src/main/java/io/vertx/openapi/contract/impl/ServerImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/ServerImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.contract.impl;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.openapi.contract.Server;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static io.vertx.openapi.contract.OpenAPIContractException.createInvalidContract;
+import static io.vertx.openapi.contract.OpenAPIContractException.createUnsupportedFeature;
+
+public class ServerImpl implements Server {
+
+  private static final String KEY_URL = "url";
+
+  private final String basePath;
+
+  private final String url;
+
+  private final JsonObject serverModel;
+
+  public ServerImpl(JsonObject serverModel) {
+    this.serverModel = serverModel;
+    this.url = serverModel.getString(KEY_URL); // is required should be validated by the contract schema
+    if (url.contains("{")) {
+      throw createUnsupportedFeature("Server Variables");
+    }
+    try {
+      this.basePath = new URL(url.endsWith("/") ? url.substring(0, url.length() - 1) : url).getPath();
+    } catch (MalformedURLException e) {
+      throw createInvalidContract("The specified URL is malformed: " + url, e);
+    }
+  }
+
+  @Override
+  public JsonObject getOpenAPIModel() {
+    return serverModel.copy();
+  }
+
+  @Override
+  public String getURL() {
+    return url;
+  }
+
+  @Override
+  public String getBasePath() {
+    return basePath;
+  }
+}

--- a/src/main/java/io/vertx/openapi/impl/Utils.java
+++ b/src/main/java/io/vertx/openapi/impl/Utils.java
@@ -68,6 +68,7 @@ public final class Utils {
    * @param yaml yaml map
    * @return json map
    */
+  @SuppressWarnings("unchecked")
   private static Map<String, Object> jsonify(Map<Object, Object> yaml) {
     final Map<String, Object> json = new LinkedHashMap<>();
 

--- a/src/main/java/io/vertx/openapi/validation/RequestUtils.java
+++ b/src/main/java/io/vertx/openapi/validation/RequestUtils.java
@@ -80,7 +80,7 @@ public class RequestUtils {
           headers.put(param.getName(), extractHeaders(request, param));
           break;
         case PATH:
-          int segment = findPathSegment(operation.getOpenAPIPath(), param.getName());
+          int segment = findPathSegment(operation.getAbsoluteOpenAPIPath(), param.getName());
           pathParams.put(param.getName(), extractPathParameters(request, segment));
           break;
         case QUERY:

--- a/src/test/java/io/vertx/openapi/contract/impl/OperationImplTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/OperationImplTest.java
@@ -76,7 +76,7 @@ class OperationImplTest {
     HttpMethod method = HttpMethod.valueOf(testDataObject.getString("method").toUpperCase());
     JsonObject operationModel = testDataObject.getJsonObject("operationModel");
     List<Parameter> pathParams = parseParameters(path, testDataObject.getJsonArray("pathParams", EMPTY_JSON_ARRAY));
-    return new OperationImpl(path, method, operationModel, pathParams);
+    return new OperationImpl("/absolute" + path, path, method, operationModel, pathParams);
   }
 
   @ParameterizedTest(name = "{index} should throw an exception for scenario: {0}")
@@ -107,6 +107,7 @@ class OperationImplTest {
     OperationImpl operation = fromTestData(testId, validTestData);
     assertThat(operation.getOperationId()).isEqualTo("showPetById");
     assertThat(operation.getOpenAPIPath()).isEqualTo("/pets/{petId}");
+    assertThat(operation.getAbsoluteOpenAPIPath()).isEqualTo("/absolute/pets/{petId}");
     assertThat(operation.getHttpMethod()).isEqualTo(GET);
     assertThat(operation.getTags()).containsExactly("pets", "foo");
     assertThat(operation.getRequestBody()).isNull();

--- a/src/test/java/io/vertx/openapi/contract/impl/PathImplTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/PathImplTest.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.nio.file.Path;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.vertx.openapi.impl.Utils.EMPTY_JSON_OBJECT;
 import static io.vertx.openapi.contract.impl.PathImpl.INVALID_CURLY_BRACES;
+import static io.vertx.openapi.impl.Utils.EMPTY_JSON_OBJECT;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(VertxExtension.class)
@@ -36,7 +36,7 @@ class PathImplTest {
   private static final Path RESOURCE_PATH = ResourceHelper.getRelatedTestResourcePath(PathImplTest.class);
 
   private static final Path VALID_PATHS_JSON = RESOURCE_PATH.resolve("path_valid.json");
-
+  private static final String BASE_PATH = "";
   private static JsonObject validTestData;
 
   @BeforeAll
@@ -48,7 +48,7 @@ class PathImplTest {
     JsonObject testDataObject = testData.getJsonObject(id);
     String name = testDataObject.getString("name");
     JsonObject pathModel = testDataObject.getJsonObject("pathModel");
-    return new PathImpl(name, pathModel);
+    return new PathImpl(BASE_PATH, name, pathModel);
   }
 
   @Test
@@ -72,7 +72,7 @@ class PathImplTest {
   @Test
   void testWildcardInPath() {
     OpenAPIContractException exception =
-      assertThrows(OpenAPIContractException.class, () -> new PathImpl("/pets/*", EMPTY_JSON_OBJECT));
+      assertThrows(OpenAPIContractException.class, () -> new PathImpl(BASE_PATH, "/pets/*", EMPTY_JSON_OBJECT));
     String expectedMsg = "The passed OpenAPI contract is invalid: Paths must not have a wildcard (asterisk): /pets/*";
     assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);
   }
@@ -82,7 +82,7 @@ class PathImplTest {
     "/foo{param}bar"})
   void testWrongCurlyBracesInPath(String path) {
     OpenAPIContractException exception =
-      assertThrows(OpenAPIContractException.class, () -> new PathImpl(path, EMPTY_JSON_OBJECT));
+      assertThrows(OpenAPIContractException.class, () -> new PathImpl(BASE_PATH, path, EMPTY_JSON_OBJECT));
     String expectedMsg =
       "The passed OpenAPI contract is invalid: Curly brace MUST be the first/last character in a path segment (/{parameterName}/): " + path;
     assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);
@@ -97,6 +97,13 @@ class PathImplTest {
   @Test
   void testCutTrailingSlash() {
     String expected = "/pets";
-    assertThat(new PathImpl(expected + "/", EMPTY_JSON_OBJECT).getName()).isEqualTo(expected);
+    assertThat(new PathImpl(BASE_PATH, expected + "/", EMPTY_JSON_OBJECT).getName()).isEqualTo(expected);
+  }
+
+  @Test
+  void testGetAbsolutePath() {
+    String expected = "/base/foo";
+    assertThat(new PathImpl("/base", "/foo", EMPTY_JSON_OBJECT).getAbsolutePath()).isEqualTo(expected);
+    assertThat(new PathImpl("/base/", "/foo", EMPTY_JSON_OBJECT).getAbsolutePath()).isEqualTo(expected);
   }
 }

--- a/src/test/java/io/vertx/openapi/contract/impl/ServerImplTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/ServerImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.contract.impl;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.openapi.contract.ContractErrorType;
+import io.vertx.openapi.contract.OpenAPIContractException;
+import io.vertx.openapi.contract.Server;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ServerImplTest {
+
+  @Test
+  void testGetters() {
+    String url = "http://foo.bar/foobar";
+    JsonObject model = new JsonObject().put("url", url);
+    Server server = new ServerImpl(model);
+
+    assertThat(server.getOpenAPIModel()).isEqualTo(model);
+    assertThat(server.getURL()).isEqualTo(url);
+    assertThat(server.getBasePath()).isEqualTo("/foobar");
+  }
+
+  private static Stream<Arguments> testBasePathExtraction() {
+    return Stream.of(
+      Arguments.of("https://example.com", ""),
+      Arguments.of("https://example.com/", ""),
+      Arguments.of("https://example.com/foo", "/foo"),
+      Arguments.of("https://example.com/foo/", "/foo"),
+      Arguments.of("https://example.com/foo/bar", "/foo/bar")
+    );
+  }
+
+  @ParameterizedTest(name = "{index} BasePath extraction: {0} should result into {1}")
+  @MethodSource
+  void testBasePathExtraction(String url, String basePath) {
+    JsonObject model = new JsonObject().put("url", url);
+    Server server = new ServerImpl(model);
+    assertThat(server.getBasePath()).isEqualTo(basePath);
+  }
+
+  @Test
+  void testExceptions() {
+    String msgUnsupported = "The passed OpenAPI contract contains a feature that is not supported: Server Variables";
+
+    OpenAPIContractException exceptionUnsupported =
+      assertThrows(OpenAPIContractException.class,
+        () -> new ServerImpl(new JsonObject().put("url", "http://{foo}.bar")));
+    assertThat(exceptionUnsupported.type()).isEqualTo(ContractErrorType.UNSUPPORTED_FEATURE);
+    assertThat(exceptionUnsupported).hasMessageThat().isEqualTo(msgUnsupported);
+
+    String msgInvalid = "The passed OpenAPI contract is invalid: The specified URL is malformed: http://foo.bar:-80";
+    OpenAPIContractException exceptionInvalid =
+      assertThrows(OpenAPIContractException.class,
+        () -> new ServerImpl(new JsonObject().put("url", "http://foo.bar:-80")));
+    assertThat(exceptionInvalid.type()).isEqualTo(ContractErrorType.INVALID_SPEC);
+    assertThat(exceptionInvalid).hasMessageThat().isEqualTo(msgInvalid);
+  }
+}

--- a/src/test/java/io/vertx/openapi/test/E2ETest.java
+++ b/src/test/java/io/vertx/openapi/test/E2ETest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.test;
+
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.openapi.contract.OpenAPIContract;
+import io.vertx.openapi.test.base.HttpServerTestBase;
+import io.vertx.openapi.validation.RequestValidator;
+import io.vertx.openapi.validation.ResponseValidator;
+import io.vertx.openapi.validation.ValidatableResponse;
+import io.vertx.openapi.validation.ValidatedRequest;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
+import static io.vertx.openapi.ResourceHelper.getRelatedTestResourcePath;
+import static io.vertx.openapi.ResourceHelper.loadJson;
+
+// We need to enforce sequential execution, because the tests are manipulating fields
+@Execution(ExecutionMode.SAME_THREAD)
+class E2ETest extends HttpServerTestBase {
+
+  private OpenAPIContract contract;
+  private RequestValidator requestValidator;
+  private ResponseValidator responseValidator;
+
+  Future<Void> setupContract(String basePath, VertxTestContext testContext) {
+    JsonObject contractJson = loadJson(vertx, getRelatedTestResourcePath(E2ETest.class).resolve("petstore.json"));
+    // Modify base path
+    JsonObject server = contractJson.getJsonArray("servers").getJsonObject(0);
+    server.put("url", server.getString("url") + basePath);
+    return OpenAPIContract.from(vertx, contractJson).onComplete(testContext.succeeding(contract -> {
+      this.contract = contract;
+      this.requestValidator = RequestValidator.create(vertx, contract);
+      this.responseValidator = ResponseValidator.create(vertx, contract);
+    })).mapEmpty();
+  }
+
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  @ParameterizedTest(name = "{index} Test with base path: {0}")
+  @ValueSource(strings = {"", "/base", "/base/"})
+  void testExtractPath(String basePath, VertxTestContext testContext) {
+    int expectedPetId = 1;
+    JsonObject expectedPet = new JsonObject().put("id", 1).put("name", "FooBar");
+
+    setupContract(basePath, testContext).compose(v -> createValidationHandler(req -> {
+      testContext.verify(() -> {
+        int petId = req.getPathParameters().get("petId").getInteger();
+        assertThat(petId).isEqualTo(expectedPetId);
+      });
+      return ValidatableResponse.create(200, expectedPet.toBuffer(), APPLICATION_JSON.toString());
+    }, contract.operation("showPetById").getOperationId(), testContext)).compose(v -> {
+      String bp = basePath.endsWith("/") ? basePath.substring(0, basePath.length() - 1) : basePath;
+      Future<HttpClientRequest> req = createRequest(HttpMethod.GET, bp + "/pets/" + expectedPetId);
+      return request(req, resp -> resp.body().onComplete(testContext.succeeding(
+        body -> testContext.verify(() -> {
+          assertThat(resp.statusCode()).isEqualTo(200);
+          assertThat(body.toJsonObject()).isEqualTo(expectedPet);
+          testContext.completeNow();
+        }))), testContext);
+    }).onFailure(testContext::failNow);
+  }
+
+  private Future<Void> request(Future<HttpClientRequest> request, Consumer<HttpClientResponse> verifier,
+    VertxTestContext testContext) {
+    return request.compose(HttpClientRequest::send)
+      .onSuccess(response -> testContext.verify(() -> verifier.accept(response))).onFailure(testContext::failNow)
+      .mapEmpty();
+  }
+
+  private Future<Void> createValidationHandler(Function<ValidatedRequest, ValidatableResponse> processor,
+    String operationId, VertxTestContext testContext) {
+    return createServer(request -> requestValidator.validate(request, operationId)
+      .map(processor).compose(validatableResponse -> responseValidator.validate(validatableResponse, operationId))
+      .compose(validatedResponse -> validatedResponse.send(request.response()))
+      .onFailure(testContext::failNow)).onFailure(testContext::failNow);
+  }
+}

--- a/src/test/java/io/vertx/openapi/validation/RequestUtilsTest.java
+++ b/src/test/java/io/vertx/openapi/validation/RequestUtilsTest.java
@@ -195,7 +195,7 @@ class RequestUtilsTest extends HttpServerTestBase {
   @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
   void testExtractPath(Parameter parameter, Style style, String path, String expected, VertxTestContext testContext) {
     Operation mockedOperation = mockOperation(parameter);
-    when(mockedOperation.getOpenAPIPath()).thenReturn("/test/{foo}");
+    when(mockedOperation.getAbsoluteOpenAPIPath()).thenReturn("/test/{foo}");
 
     createValidationHandler(params -> {
       assertThat(params.getPathParameters().get(parameter.getName()).getString()).isEqualTo(expected);

--- a/src/test/resources/io/vertx/openapi/test/petstore.json
+++ b/src/test/resources/io/vertx/openapi/test/petstore.json
@@ -1,0 +1,222 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "identifier": "MIT",
+      "name": "MIT License"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://petstore.swagger.io"
+    }
+  ],
+  "security": [
+    {
+      "BasicAuth": []
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paged array of pets",
+            "headers": {
+              "x-next": {
+                "description": "A link to the next page of responses",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pets"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "requestBody": {
+          "description": "Create a new pet in the store",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Pets": {
+        "type": "array",
+        "maxItems": 100,
+        "items": {
+          "$ref": "#/components/schemas/Pet"
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "BasicAuth": {
+        "scheme": "basic",
+        "type": "http"
+      }
+    }
+  }
+}

--- a/src/test/resources/io/vertx/openapi/validation/guestbook.yaml
+++ b/src/test/resources/io/vertx/openapi/validation/guestbook.yaml
@@ -7,7 +7,7 @@ info:
     identifier: MIT
     name: MIT License
 servers:
-  - url: https://example.com/guestbook/v1
+  - url: https://example.com/
 security:
   - BasicAuth: [ ]
 paths:


### PR DESCRIPTION
Motivation:

In case your OpenAPI contract defines the endpoint "/pets", but it is mounted
on "/myapp/pets", you can specify the base path within a server object.
