### PR TITLE
rename findSecurityScheme into securityScheme

### DIFF
--- a/src/main/java/io/vertx/openapi/contract/OpenAPIContract.java
+++ b/src/main/java/io/vertx/openapi/contract/OpenAPIContract.java
@@ -73,7 +73,7 @@ public interface OpenAPIContract {
    * @return A succeeded {@link Future} holding an {@link OpenAPIContract} instance, otherwise a failed {@link Future}.
    */
   static Future<OpenAPIContract> from(Vertx vertx, String unresolvedContractPath,
-    Map<String, String> additionalContractFiles) {
+                                      Map<String, String> additionalContractFiles) {
 
     Map<String, Future<JsonObject>> jsonFilesFuture = new HashMap<>();
     jsonFilesFuture.put(unresolvedContractPath, readYamlOrJson(vertx, unresolvedContractPath));
@@ -98,7 +98,7 @@ public interface OpenAPIContract {
    * @return A succeeded {@link Future} holding an {@link OpenAPIContract} instance, otherwise a failed {@link Future}.
    */
   static Future<OpenAPIContract> from(Vertx vertx, JsonObject unresolvedContract,
-    Map<String, JsonObject> additionalContractFiles) {
+                                      Map<String, JsonObject> additionalContractFiles) {
     if (unresolvedContract == null) {
       return failedFuture(createInvalidContract("Spec must not be null"));
     }
@@ -194,23 +194,26 @@ public interface OpenAPIContract {
    *
    * @param urlPath The path of the request.
    * @param method  The method of the request.
-   * @return the found {@link Operation} object, or null if the passed path and method doesn't match any {@link Operation} object.
+   * @return the found {@link Operation} object, or null if the passed path and method doesn't match any
+   * {@link Operation} object.
    */
   @Nullable
   Operation findOperation(String urlPath, HttpMethod method);
 
   /**
    * Returns the applicable list of global security requirements (scopes) or empty list.
+   *
    * @return The related security requirement.
    */
   List<SecurityRequirement> getSecurityRequirements();
 
   /**
-   * Finds the related {@link SecurityScheme} object based on the passed name.
+   * Gets the related {@link SecurityScheme} object based on the passed name.
    *
    * @param name The name of the security scheme.
-   * @return the found {@link SecurityScheme} object, or null if the passed path and method doesn't match any {@link Operation} object.
+   * @return the found {@link SecurityScheme} object, or null if the passed path and method doesn't match any
+   * {@link Operation} object.
    */
   @Nullable
-  SecurityScheme findSecurityScheme(String name);
+  SecurityScheme securityScheme(String name);
 }

--- a/src/main/java/io/vertx/openapi/contract/impl/OpenAPIContractImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/OpenAPIContractImpl.java
@@ -16,7 +16,13 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.json.schema.SchemaRepository;
-import io.vertx.openapi.contract.*;
+import io.vertx.openapi.contract.OpenAPIContract;
+import io.vertx.openapi.contract.OpenAPIVersion;
+import io.vertx.openapi.contract.Operation;
+import io.vertx.openapi.contract.Path;
+import io.vertx.openapi.contract.SecurityRequirement;
+import io.vertx.openapi.contract.SecurityScheme;
+import io.vertx.openapi.contract.Server;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -208,9 +214,7 @@ public class OpenAPIContractImpl implements OpenAPIContract {
   }
 
   @Override
-  public SecurityScheme findSecurityScheme(String name) {
-    return securityRequirements != null ?
-      securitySchemes.get(name) :
-      null;
+  public SecurityScheme securityScheme(String name) {
+    return securitySchemes.get(name);
   }
 }

--- a/src/test/java/io/vertx/openapi/contract/impl/OpenAPIContractImplTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/OpenAPIContractImplTest.java
@@ -157,6 +157,7 @@ class OpenAPIContractImplTest {
 
     assertThat(contract.findOperation("/v1/pets/123/134", GET)).isNull();
     assertThat(contract.findOperation("/v1/pets/123", PATCH)).isNull();
+    assertThat(contract.securityScheme("BasicAuth")).isNotNull();
   }
 
   @Test

--- a/src/test/java/io/vertx/openapi/contract/impl/SecuritySchemeImplTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/SecuritySchemeImplTest.java
@@ -90,12 +90,4 @@ class SecuritySchemeImplTest {
     SecuritySchemeImpl secReq = fromTestData(testId, validTestData);
     verifier.accept(secReq);
   }
-
-//  @Test
-//  void testGetScopesError() {
-//    SecuritySchemeImpl secReq = fromTestData("0001_Test_One_Name_No_Scope", validTestData);
-//    IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class,
-//      () -> secReq.getScopes("Hodor"));
-//    assertThat(exception).hasMessageThat().isEqualTo("No security requirement with name Hodor");
-//  }
 }


### PR DESCRIPTION
Motivation:

rename findSecurityScheme into securityScheme to have a more consistent API.
