### PR TITLE
fix: don't copy model schema

### DIFF
--- a/src/main/java/io/vertx/openapi/contract/OpenAPIObject.java
+++ b/src/main/java/io/vertx/openapi/contract/OpenAPIObject.java
@@ -13,14 +13,23 @@
 package io.vertx.openapi.contract;
 
 import io.vertx.core.json.JsonObject;
+import io.vertx.json.schema.impl.JsonObjectProxy;
 
 public interface OpenAPIObject {
 
   /**
    * Returns the part of the related OpenAPI specification which is represented by the OpenAPI object that is
    * implementing this interface.
+   * <p></p>
+   * <b>Warning:</b>
+   * <ul>
+   *   <li> In case the contract <b>contains circular references</b>, the returned object is may of type
+   *   {@link JsonObjectProxy}, which has some <b>limitations</b> when it comes to copying or serializing.</li>
+   *   <li>Due to these limitations, the reference of the <b>original object is returned</b>. Because of this be very
+   *   <b>careful when modifying</b> the returned object.</li>
+   * </ul>
    *
-   * @return a {@link  JsonObject} that represents this part of the related OpenAPI specification.
+   * @return a {@link JsonObject} that represents this part of the related OpenAPI specification.
    */
   JsonObject getOpenAPIModel();
 }

--- a/src/main/java/io/vertx/openapi/contract/impl/MediaTypeImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/MediaTypeImpl.java
@@ -47,6 +47,6 @@ public class MediaTypeImpl implements MediaType {
 
   @Override
   public JsonObject getOpenAPIModel() {
-    return mediaTypeModel.copy();
+    return mediaTypeModel;
   }
 }

--- a/src/main/java/io/vertx/openapi/contract/impl/OperationImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/OperationImpl.java
@@ -143,7 +143,7 @@ public class OperationImpl implements Operation {
 
   @Override
   public JsonObject getOpenAPIModel() {
-    return operationModel.copy();
+    return operationModel;
   }
 
   @Override

--- a/src/main/java/io/vertx/openapi/contract/impl/ParameterImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/ParameterImpl.java
@@ -154,7 +154,7 @@ public class ParameterImpl implements Parameter {
 
   @Override
   public JsonObject getOpenAPIModel() {
-    return parameterModel.copy();
+    return parameterModel;
   }
 
   @Override
@@ -162,7 +162,8 @@ public class ParameterImpl implements Parameter {
     return schema;
   }
 
-  @Override public SchemaType getSchemaType() {
+  @Override
+  public SchemaType getSchemaType() {
     return schemaType;
   }
 }

--- a/src/main/java/io/vertx/openapi/contract/impl/PathImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/PathImpl.java
@@ -109,7 +109,7 @@ public class PathImpl implements Path {
 
   @Override
   public JsonObject getOpenAPIModel() {
-    return pathModel.copy();
+    return pathModel;
   }
 
   public String getAbsolutePath() {

--- a/src/main/java/io/vertx/openapi/contract/impl/RequestBodyImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/RequestBodyImpl.java
@@ -66,7 +66,7 @@ public class RequestBodyImpl implements RequestBody {
 
   @Override
   public JsonObject getOpenAPIModel() {
-    return requestBodyModel.copy();
+    return requestBodyModel;
   }
 
   @Override

--- a/src/main/java/io/vertx/openapi/contract/impl/ResponseImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/ResponseImpl.java
@@ -80,7 +80,7 @@ public class ResponseImpl implements Response {
 
   @Override
   public JsonObject getOpenAPIModel() {
-    return responseModel.copy();
+    return responseModel;
   }
 
   @Override

--- a/src/main/java/io/vertx/openapi/contract/impl/ServerImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/ServerImpl.java
@@ -46,7 +46,7 @@ public class ServerImpl implements Server {
 
   @Override
   public JsonObject getOpenAPIModel() {
-    return serverModel.copy();
+    return serverModel;
   }
 
   @Override


### PR DESCRIPTION
The model schema could be a JSON proxy object and contain a circular references, which can't be copied.