### PR TITLE
fix: don't omit empty JsonArrays or JsonObjects

### DIFF
--- a/src/main/java/io/vertx/openapi/validation/impl/ValidatedResponseImpl.java
+++ b/src/main/java/io/vertx/openapi/validation/impl/ValidatedResponseImpl.java
@@ -29,7 +29,7 @@ public class ValidatedResponseImpl implements ValidatedResponse {
   private final ValidatableResponse unvalidated;
 
   public ValidatedResponseImpl(Map<String, ResponseParameter> headers, ResponseParameter body,
-    ValidatableResponse unvalidated) {
+                               ValidatableResponse unvalidated) {
     this.headers = safeUnmodifiableMap(headers);
     this.body = body == null ? new RequestParameterImpl(null) : body;
     this.unvalidated = unvalidated;
@@ -60,7 +60,7 @@ public class ValidatedResponseImpl implements ValidatedResponse {
       }
     }
 
-    if (body.isEmpty()) {
+    if (body.isNull() || (body.isString() && body.getString().isEmpty()) || (body.isBuffer() && body.getBuffer().length() == 0)) {
       return serverResponse.send();
     } else {
       serverResponse.headers().add(CONTENT_TYPE.toString(), unvalidated.getContentType());

--- a/src/test/java/io/vertx/openapi/validation/impl/ValidatedResponseImplTest.java
+++ b/src/test/java/io/vertx/openapi/validation/impl/ValidatedResponseImplTest.java
@@ -96,6 +96,16 @@ class ValidatedResponseImplTest extends HttpServerTestBase {
     }).compose(v -> verifyResponse(201, Buffer.buffer(), headersExpected, testContext));
   }
 
+  @Test
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void testResponseWithEmptyJsonArray(VertxTestContext testContext) {
+    Buffer body = new JsonArray().toBuffer();
+    createServer(request -> {
+      responseValidator.validate(ValidatableResponse.create(200, body, APPLICATION_JSON.toString()), "listPets")
+        .compose(validatedResponse -> validatedResponse.send(request.response())).onFailure(testContext::failNow);
+    }).compose(v -> verifyResponse(200, body, buildHeaders(body), testContext));
+  }
+
   private Map<String, String> buildHeaders(Buffer body) {
     return Maps.newHashMap(ImmutableMap.of(CONTENT_TYPE.toString(), APPLICATION_JSON.toString(),
       CONTENT_LENGTH.toString(), "" + body.length()));


### PR DESCRIPTION
If your response was an empty JsonArray or JsonObject and was sent back by `ValidatedResponse`, it looses its content.