### PR TITLE
fix: don't copy raw contract

### DIFF
--- a/src/main/java/io/vertx/openapi/contract/impl/OpenAPIContractImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/OpenAPIContractImpl.java
@@ -99,7 +99,8 @@ public class OpenAPIContractImpl implements OpenAPIContract {
       .getJsonObject(KEY_PATHS, EMPTY_JSON_OBJECT)
       .stream()
       .filter(JsonSchema.EXCLUDE_ANNOTATION_ENTRIES)
-      .map(pathEntry -> new PathImpl(basePath, pathEntry.getKey(), (JsonObject) pathEntry.getValue(), securityRequirements))
+      .map(pathEntry -> new PathImpl(basePath, pathEntry.getKey(), (JsonObject) pathEntry.getValue(),
+        securityRequirements))
       .collect(toList());
 
     List<PathImpl> sortedPaths = applyMountOrder(unsortedPaths);
@@ -187,7 +188,7 @@ public class OpenAPIContractImpl implements OpenAPIContract {
 
   @Override
   public JsonObject getRawContract() {
-    return rawContract.copy();
+    return rawContract;
   }
 
   @Override


### PR DESCRIPTION
Copying the contract would fail if it contains circular references.
