### PR TITLE
feat: add getExtensions method to every OpenAPIObject

### DIFF
--- a/src/main/java/io/vertx/openapi/contract/OpenAPIObject.java
+++ b/src/main/java/io/vertx/openapi/contract/OpenAPIObject.java
@@ -15,6 +15,11 @@ package io.vertx.openapi.contract;
 import io.vertx.core.json.JsonObject;
 import io.vertx.json.schema.impl.JsonObjectProxy;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.function.Function.identity;
+
 public interface OpenAPIObject {
 
   /**
@@ -32,4 +37,17 @@ public interface OpenAPIObject {
    * @return a {@link JsonObject} that represents this part of the related OpenAPI specification.
    */
   JsonObject getOpenAPIModel();
+
+  /**
+   * Returns the
+   * <a href="https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-Extensions">Specification Extensions</a> of this OpenAPIObject.
+   * <p></p>
+   * According to the specification, the extension can be of <b>any type</b>.
+   *
+   * @return the extensions or an empty map if there are none.
+   */
+  default Map<String, Object> getExtensions() {
+    return getOpenAPIModel().fieldNames().stream().filter(fieldName -> fieldName.startsWith("x-"))
+      .collect(Collectors.toMap(identity(), getOpenAPIModel()::getValue));
+  }
 }

--- a/src/main/java/io/vertx/openapi/contract/impl/OperationImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/OperationImpl.java
@@ -17,8 +17,13 @@ import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.json.JsonObject;
 import io.vertx.json.schema.JsonSchema;
-import io.vertx.openapi.contract.*;
+import io.vertx.openapi.contract.Operation;
+import io.vertx.openapi.contract.Parameter;
+import io.vertx.openapi.contract.RequestBody;
+import io.vertx.openapi.contract.Response;
+import io.vertx.openapi.contract.SecurityRequirement;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -59,14 +64,20 @@ public class OperationImpl implements Operation {
   private final Map<Integer, Response> responses;
   private final String absolutePath;
   private final List<SecurityRequirement> securityRequirements;
+  private final Map<String, Object> extensions;
 
   public OperationImpl(String absolutePath, String path, HttpMethod method, JsonObject operationModel,
-                       List<Parameter> pathParameters, List<SecurityRequirement> globalSecReq) {
+                       List<Parameter> pathParameters, Map<String, Object> pathExtensions,
+                       List<SecurityRequirement> globalSecReq) {
     this.absolutePath = absolutePath;
     this.operationId = operationModel.getString(KEY_OPERATION_ID);
     this.method = method;
     this.path = path;
     this.operationModel = operationModel;
+
+    HashMap<String, Object> allExtensions = new HashMap<>(Operation.super.getExtensions());
+    pathExtensions.forEach(allExtensions::putIfAbsent);
+    this.extensions = unmodifiableMap(allExtensions);
 
     this.tags =
       unmodifiableList(operationModel.getJsonArray(KEY_TAGS, EMPTY_JSON_ARRAY).stream().map(Object::toString).collect(
@@ -185,5 +196,10 @@ public class OperationImpl implements Operation {
   @Override
   public List<SecurityRequirement> getSecurityRequirements() {
     return securityRequirements;
+  }
+
+  @Override
+  public Map<String, Object> getExtensions() {
+    return extensions;
   }
 }

--- a/src/main/java/io/vertx/openapi/contract/impl/PathImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/PathImpl.java
@@ -82,7 +82,8 @@ public class PathImpl implements Path {
 
     List<Operation> ops = new ArrayList<>();
     SUPPORTED_METHODS.forEach((methodName, method) -> Optional.ofNullable(pathModel.getJsonObject(methodName))
-      .map(operationModel -> new OperationImpl(absolutePath, name, method, operationModel, parameters, globalSecReq))
+      .map(operationModel -> new OperationImpl(absolutePath, name, method, operationModel, parameters,
+        getExtensions(), globalSecReq))
       .ifPresent(ops::add));
     this.operations = unmodifiableList(ops);
   }

--- a/src/test/java/io/vertx/openapi/contract/OpenAPIObjectTest.java
+++ b/src/test/java/io/vertx/openapi/contract/OpenAPIObjectTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, SAP SE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.contract;
+
+import com.google.common.collect.ImmutableMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.vertx.openapi.ResourceHelper.getRelatedTestResourcePath;
+import static io.vertx.openapi.ResourceHelper.loadJson;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+@ExtendWith(VertxExtension.class)
+class OpenAPIObjectTest {
+  private static final Path MODELS_WITH_EXTENSIONS = getRelatedTestResourcePath(OpenAPIObjectTest.class).resolve(
+    "models_with_extensions.json");
+  private static JsonObject testData;
+
+  @BeforeAll
+  @Timeout(value = 2, timeUnit = SECONDS)
+  static void setUp(Vertx vertx) {
+    testData = loadJson(vertx, MODELS_WITH_EXTENSIONS);
+  }
+
+  private static Stream<Arguments> provideScenarios() {
+    Map<String, Object> oneString = ImmutableMap.of("x-some-string", "someString");
+    Map<String, Object> oneStringOneArray = ImmutableMap.<String, Object>builder().putAll(oneString)
+      .put("x-some-array", new JsonArray().add("foo").add("bar")).build();
+    Map<String, Object> oneStringOneArrayOneNumber = ImmutableMap.<String, Object>builder().putAll(oneStringOneArray)
+      .put("x-some-number", 1337).build();
+
+    return Stream.of(
+      Arguments.of("0000_Operation_With_One_String", oneString),
+      Arguments.of("0001_Operation_With_One_String_One_Array", oneStringOneArray),
+      Arguments.of("0002_Operation_With_One_String_One_Array_One_Number", oneStringOneArrayOneNumber)
+    );
+  }
+
+  @ParameterizedTest(name = "{index} should throw an exception for scenario: {0}")
+  @MethodSource(value = "provideScenarios")
+  void testGetExtensions(String testId, Map<String, Object> expected) {
+    OpenAPIObject object = () -> testData.getJsonObject(testId);
+    assertThat(object.getExtensions()).containsExactlyEntriesIn(expected);
+  }
+}

--- a/src/test/resources/io/vertx/openapi/contract/impl/operation_valid.json
+++ b/src/test/resources/io/vertx/openapi/contract/impl/operation_valid.json
@@ -189,5 +189,31 @@
         }
       }
     }
+  },
+  "0005_Test_Merge_Extensions": {
+    "path": "/pets",
+    "method": "GET",
+    "operationModel": {
+      "security": [
+        {
+          "api_key": []
+        }
+      ],
+      "operationId": "getPet",
+      "x-some-string": "someString",
+      "x-some-number": 1337,
+      "responses": {
+        "default": {
+          "description": "unexpected error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/src/test/resources/io/vertx/openapi/contract/models_with_extensions.json
+++ b/src/test/resources/io/vertx/openapi/contract/models_with_extensions.json
@@ -1,0 +1,108 @@
+{
+  "0000_Operation_With_One_String": {
+    "description": "Returns pets based on ID",
+    "summary": "Find pets by ID",
+    "operationId": "getPetsById",
+    "x-some-string": "someString",
+    "responses": {
+      "200": {
+        "x-some-response-extension": "foo",
+        "description": "pet response",
+        "content": {
+          "*/*": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          }
+        }
+      },
+      "default": {
+        "description": "error payload",
+        "content": {
+          "text/html": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "0001_Operation_With_One_String_One_Array": {
+    "description": "Returns pets based on ID",
+    "summary": "Find pets by ID",
+    "operationId": "getPetsById",
+    "x-some-string": "someString",
+    "x-some-array": [
+      "foo",
+      "bar"
+    ],
+    "responses": {
+      "200": {
+        "x-some-response-extension": "foo",
+        "description": "pet response",
+        "content": {
+          "*/*": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          }
+        }
+      },
+      "default": {
+        "description": "error payload",
+        "content": {
+          "text/html": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "0002_Operation_With_One_String_One_Array_One_Number": {
+    "description": "Returns pets based on ID",
+    "summary": "Find pets by ID",
+    "x-some-number": 1337,
+    "operationId": "getPetsById",
+    "x-some-string": "someString",
+    "x-some-array": [
+      "foo",
+      "bar"
+    ],
+    "responses": {
+      "200": {
+        "x-some-response-extension": "foo",
+        "description": "pet response",
+        "content": {
+          "*/*": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          }
+        }
+      },
+      "default": {
+        "description": "error payload",
+        "content": {
+          "text/html": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorModel"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
The Extensions returned by an Operation also include the extensions of the related Path, similar to the parameters.

solves issue #25 
