### PR TITLE
Find operations fix for Issue #47

### DIFF
--- a/src/main/java/io/vertx/openapi/contract/impl/PathFinder.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/PathFinder.java
@@ -85,6 +85,16 @@ class PathFinder {
   }
 
   // VisibleForTesting
+
+  /**
+   * Test the total number of segments the path template that match the given a path segment. If the path doesn't match
+   * in one or more places, then testSegments will return -1 regardless.
+   *
+   * @param pathSegments The related path segment we are testing.
+   * @param pathTemplateSegments The related path template we are testing against.
+   * @return The total number of segments that match with a bias towards segments that come first (left biased).
+   * If the path segment doesn't match in one or more places, then we return -1 (path doesn't match).
+   */
   int testSegments(String[] pathSegments, String[] pathTemplateSegments) {
     int numPerfectMatches = 0;
     for (int i = 0; i < pathTemplateSegments.length; i++) {
@@ -92,7 +102,7 @@ class PathFinder {
       if (templateSegment.contains("{")) {
         // valid segment
       } else if(templateSegment.equals(pathSegments[i])){
-        // We want to have a bias paths that match "more" perfectly from left to right.
+        // We want to have a bias to paths that match "more" perfectly from left to right.
         numPerfectMatches += pathTemplateSegments.length - i;
       } else {
         return -1;

--- a/src/main/java/io/vertx/openapi/contract/impl/PathFinder.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/PathFinder.java
@@ -71,26 +71,19 @@ class PathFinder {
       }
     }
 
-    List<Path> potentialPaths = new ArrayList<>();
-    List<String[]> potentialPathSegments = new ArrayList<>();
+    Path bestMatchedPath = null;
+    int currentMatchedSegments = -1;
     for (Entry<Path, String[]> entry : segmentsWithTemplating.getOrDefault(segments.length, emptyMap()).entrySet()) {
       if (testSegments(segments, entry.getValue())) {
-        potentialPaths.add(entry.getKey());
-        potentialPathSegments.add(entry.getValue());
+        int matchedSegments = getNumSegmentsMatching(segments, entry.getValue());
+        if(matchedSegments > currentMatchedSegments) {
+          bestMatchedPath = entry.getKey();
+          currentMatchedSegments = matchedSegments;
+        }
       }
     }
 
-    if(!potentialPaths.isEmpty()) {
-      //Only 1 path matched, there are no possible conflicts here.
-      if(potentialPaths.size() == 1) {
-        return potentialPaths.get(0);
-      } else {
-        //There are more than 1 matches, so we need to resolve the path predictably.
-        return potentialPaths.get(resolveMultiPaths(segments, potentialPathSegments));
-      }
-    }
-
-    return null;
+    return bestMatchedPath;
   }
 
   // VisibleForTesting
@@ -104,21 +97,6 @@ class PathFinder {
       }
     }
     return true;
-  }
-
-  private int resolveMultiPaths(String[] segments, List<String[]> potentialPathSegments) {
-    int bestTotalNumbOfMatchingSegments = getNumSegmentsMatching(potentialPathSegments.get(0), segments);
-    int bestMatchIndex = 0;
-
-    for(int i = 1; i < potentialPathSegments.size(); i++) {
-      int numSegmentsMatching = getNumSegmentsMatching(potentialPathSegments.get(i), segments);
-      if(numSegmentsMatching > bestTotalNumbOfMatchingSegments) {
-        bestTotalNumbOfMatchingSegments = numSegmentsMatching;
-        bestMatchIndex = i;
-      }
-    }
-
-    return bestMatchIndex;
   }
 
   private int getNumSegmentsMatching(String[] pathSegments, String[] pathTemplateSegments) {

--- a/src/main/java/io/vertx/openapi/contract/impl/PathFinder.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/PathFinder.java
@@ -71,9 +71,22 @@ class PathFinder {
       }
     }
 
+    List<Path> potentialPaths = new ArrayList<>();
+    List<String[]> potentialPathSegments = new ArrayList<>();
     for (Entry<Path, String[]> entry : segmentsWithTemplating.getOrDefault(segments.length, emptyMap()).entrySet()) {
       if (testSegments(segments, entry.getValue())) {
-        return entry.getKey();
+        potentialPaths.add(entry.getKey());
+        potentialPathSegments.add(entry.getValue());
+      }
+    }
+
+    if(!potentialPaths.isEmpty()) {
+      //Only 1 path matched, there are no possible conflicts here.
+      if(potentialPaths.size() == 1) {
+        return potentialPaths.get(0);
+      } else {
+        //There are more than 1 matches, so we need to resolve the path predictably.
+        return potentialPaths.get(resolveMultiPaths(segments, potentialPathSegments));
       }
     }
 
@@ -92,4 +105,32 @@ class PathFinder {
     }
     return true;
   }
+
+  private int resolveMultiPaths(String[] segments, List<String[]> potentialPathSegments) {
+    int bestTotalNumbOfMatchingSegments = getNumSegmentsMatching(potentialPathSegments.get(0), segments);
+    int bestMatchIndex = 0;
+
+    for(int i = 1; i < potentialPathSegments.size(); i++) {
+      int numSegmentsMatching = getNumSegmentsMatching(potentialPathSegments.get(i), segments);
+      if(numSegmentsMatching > bestTotalNumbOfMatchingSegments) {
+        bestTotalNumbOfMatchingSegments = numSegmentsMatching;
+        bestMatchIndex = i;
+      }
+    }
+
+    return bestMatchIndex;
+  }
+
+  private int getNumSegmentsMatching(String[] pathSegments, String[] pathTemplateSegments) {
+    int numPerfectMatches = 0;
+
+    for (int i = 0; i < pathTemplateSegments.length; i++) {
+      String templateSegment = pathTemplateSegments[i];
+      if(templateSegment.equals(pathSegments[i])) {
+        numPerfectMatches += pathTemplateSegments.length - i + 1;
+      }
+    }
+    return numPerfectMatches;
+  }
+
 }

--- a/src/main/java/io/vertx/openapi/contract/impl/PathFinder.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/PathFinder.java
@@ -74,12 +74,10 @@ class PathFinder {
     Path bestMatchedPath = null;
     int currentMatchedSegments = -1;
     for (Entry<Path, String[]> entry : segmentsWithTemplating.getOrDefault(segments.length, emptyMap()).entrySet()) {
-      if (testSegments(segments, entry.getValue())) {
-        int matchedSegments = getNumSegmentsMatching(segments, entry.getValue());
-        if(matchedSegments > currentMatchedSegments) {
-          bestMatchedPath = entry.getKey();
-          currentMatchedSegments = matchedSegments;
-        }
+      int matchedSegments = testSegments(segments, entry.getValue());
+      if (matchedSegments > currentMatchedSegments) {
+        bestMatchedPath = entry.getKey();
+        currentMatchedSegments = matchedSegments;
       }
     }
 
@@ -87,25 +85,17 @@ class PathFinder {
   }
 
   // VisibleForTesting
-  boolean testSegments(String[] pathSegments, String[] pathTemplateSegments) {
-    for (int i = 0; i < pathTemplateSegments.length; i++) {
-      String templateSegment = pathTemplateSegments[i];
-      if (templateSegment.contains("{") || templateSegment.equals(pathSegments[i])) {
-        // valid segment
-      } else {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private int getNumSegmentsMatching(String[] pathSegments, String[] pathTemplateSegments) {
+  int testSegments(String[] pathSegments, String[] pathTemplateSegments) {
     int numPerfectMatches = 0;
-
     for (int i = 0; i < pathTemplateSegments.length; i++) {
       String templateSegment = pathTemplateSegments[i];
-      if(templateSegment.equals(pathSegments[i])) {
-        numPerfectMatches += pathTemplateSegments.length - i + 1;
+      if (templateSegment.contains("{")) {
+        // valid segment
+      } else if(templateSegment.equals(pathSegments[i])){
+        // We want to have a bias paths that match "more" perfectly from left to right.
+        numPerfectMatches += pathTemplateSegments.length - i;
+      } else {
+        return -1;
       }
     }
     return numPerfectMatches;

--- a/src/main/java/io/vertx/openapi/contract/impl/PathFinder.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/PathFinder.java
@@ -87,8 +87,8 @@ class PathFinder {
   // VisibleForTesting
 
   /**
-   * Test the total number of segments the path template that match the given a path segment. If the path doesn't match
-   * in one or more places, then testSegments will return -1 regardless.
+   * Test the total number of segments that the path template matches to the given a path segment.
+   * If the path doesn't match in one or more places, then testSegments will return -1 regardless.
    *
    * @param pathSegments The related path segment we are testing.
    * @param pathTemplateSegments The related path template we are testing against.

--- a/src/test/java/io/vertx/openapi/contract/impl/PathFinderTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/PathFinderTest.java
@@ -62,10 +62,13 @@ class PathFinderTest {
     PathImpl variableVersion = mockPath("", "/{version}/api/user");
     PathImpl withUsername = mockPath("", "/{version}/api/user/{username}");
     PathImpl withConcreteUser = mockPath("", "/{version}/api/user/hodor");
+    PathImpl withConcreteUserAndVersion = mockPath("", "/v3/api/user/hodor");
+    PathImpl withConcreteUserAndMockedApi = mockPath("", "/v3/{api}/test/user/foobar");
+    PathImpl withConcreteUserAndNotMockedApi = mockPath("", "/v3/api/{test}/user/foobar");
     PathImpl root = mockPath("", "/");
     PathImpl rootWithVersion = mockPath("", "/{version}");
 
-    List<PathImpl> paths = ImmutableList.of(v0, variableVersion, withUsername, withConcreteUser, root, rootWithVersion);
+    List<PathImpl> paths = ImmutableList.of(v0, variableVersion, withUsername, withConcreteUser, withConcreteUserAndVersion, withConcreteUserAndMockedApi, withConcreteUserAndNotMockedApi, root, rootWithVersion);
     PathFinder pathFinder = new PathFinder(paths);
 
     assertThat(pathFinder.findPath("/v0/api/user")).isEqualTo(v0);
@@ -75,6 +78,8 @@ class PathFinderTest {
     assertThat(pathFinder.findPath("/v0/api/user/foo")).isEqualTo(withUsername);
     assertThat(pathFinder.findPath("/v1/api/user/foo")).isEqualTo(withUsername);
     assertThat(pathFinder.findPath("/v1/api/user/hodor")).isEqualTo(withConcreteUser);
+    assertThat(pathFinder.findPath("/v3/api/user/hodor")).isEqualTo(withConcreteUserAndVersion);
+    assertThat(pathFinder.findPath("/v3/api/test/user/foobar")).isEqualTo(withConcreteUserAndNotMockedApi);
 
     assertThat(pathFinder.findPath("/v0/api/user/foo/age")).isNull();
     assertThat(pathFinder.findPath("/v1/api/user/foo/age")).isNull();

--- a/src/test/java/io/vertx/openapi/contract/impl/PathFinderTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/PathFinderTest.java
@@ -13,6 +13,7 @@
 package io.vertx.openapi.contract.impl;
 
 import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -54,14 +55,17 @@ class PathFinderTest {
     return mockedPath;
   }
 
-  @Test
+  // to ensure that issue 47 occur
+  @RepeatedTest(10)
   void testFindPath() {
     PathImpl v0 = mockPath("", "/v0/api/user");
     PathImpl variableVersion = mockPath("", "/{version}/api/user");
     PathImpl withUsername = mockPath("", "/{version}/api/user/{username}");
+    PathImpl withConcreteUser = mockPath("", "/{version}/api/user/hodor");
     PathImpl root = mockPath("", "/");
     PathImpl rootWithVersion = mockPath("", "/{version}");
-    List<PathImpl> paths = ImmutableList.of(v0, variableVersion, withUsername, root, rootWithVersion);
+
+    List<PathImpl> paths = ImmutableList.of(v0, variableVersion, withUsername, withConcreteUser, root, rootWithVersion);
     PathFinder pathFinder = new PathFinder(paths);
 
     assertThat(pathFinder.findPath("/v0/api/user")).isEqualTo(v0);
@@ -70,6 +74,7 @@ class PathFinderTest {
 
     assertThat(pathFinder.findPath("/v0/api/user/foo")).isEqualTo(withUsername);
     assertThat(pathFinder.findPath("/v1/api/user/foo")).isEqualTo(withUsername);
+    assertThat(pathFinder.findPath("/v1/api/user/hodor")).isEqualTo(withConcreteUser);
 
     assertThat(pathFinder.findPath("/v0/api/user/foo/age")).isNull();
     assertThat(pathFinder.findPath("/v1/api/user/foo/age")).isNull();

--- a/src/test/java/io/vertx/openapi/contract/impl/PathFinderTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/PathFinderTest.java
@@ -34,7 +34,8 @@ class PathFinderTest {
       Arguments.of("/v3/api/user", "/v3/api/user", 6),
       Arguments.of("/v3/api/user", "/{version}/api/user", 3),
       Arguments.of("/v3/api/user", "/{version}/api/users", -1),
-      Arguments.of("/v3/api/user/foo", "/{version}/api/user/{username}", 5)
+      Arguments.of("/v3/api/user/foo", "/{version}/api/user/{username}", 5),
+      Arguments.of("/v3/foo", "/{version}/{username}", 0)
     );
   }
 

--- a/src/test/java/io/vertx/openapi/contract/impl/PathFinderTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/PathFinderTest.java
@@ -31,21 +31,21 @@ class PathFinderTest {
 
   private static Stream<Arguments> testTestSegments() {
     return Stream.of(
-      Arguments.of("/v3/api/user", "/v3/api/user", true),
-      Arguments.of("/v3/api/user", "/{version}/api/user", true),
-      Arguments.of("/v3/api/user", "/{version}/api/users", false),
-      Arguments.of("/v3/api/user/foo", "/{version}/api/user/{username}", true)
+      Arguments.of("/v3/api/user", "/v3/api/user", 6),
+      Arguments.of("/v3/api/user", "/{version}/api/user", 3),
+      Arguments.of("/v3/api/user", "/{version}/api/users", -1),
+      Arguments.of("/v3/api/user/foo", "/{version}/api/user/{username}", 5)
     );
   }
 
   @ParameterizedTest(name = "Segments to test: {index} {0} and {1}")
   @MethodSource("testTestSegments")
-  void testTestSegments(String path, String templatePath, boolean equal) {
+  void testTestSegments(String path, String templatePath, int amount) {
     String[] pathSegments = path.substring(1).split("/");
     String[] pathTemplateSegments = templatePath.substring(1).split("/");
 
     PathFinder pathFinder = new PathFinder(emptyList());
-    assertThat(pathFinder.testSegments(pathSegments, pathTemplateSegments)).isEqualTo(equal);
+    assertThat(pathFinder.testSegments(pathSegments, pathTemplateSegments)).isEqualTo(amount);
   }
 
   private PathImpl mockPath(String basePath, String path) {


### PR DESCRIPTION
Motivation:

When API's have path variables like:
```
GET /users/{id}/addresses/{adr-id}
GET /users/{id}/addresses/foo
```

The operation that is found when trying to find the operation:
```
"/users/100001/addresses/foo"
```
Was unreliable and could possibly choose any of the two operations above.  Added a check that if there are multiple paths that could match the given path, then we will preferentially choose the path that matches most exactly from left to right.

In this case for:
```
"/users/100001/addresses/foo"
```

It will return the second operation as it matches 3 times exactly.
Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md ✅ 
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines ✅ 
