### PR TITLE
Adding defaultable values to Parameters if they are null

### DIFF
--- a/src/main/java/io/vertx/openapi/validation/Parameter.java
+++ b/src/main/java/io/vertx/openapi/validation/Parameter.java
@@ -137,7 +137,9 @@ interface Parameter {
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Boolean} or is null, otherwise it returns the value.
    */
-  default Boolean getBooleanOrDefault(Supplier<Boolean> defaultValue) { return isBoolean() ? (Boolean) get() : defaultValue.get(); }
+  default Boolean getBooleanOrDefault(Supplier<Boolean> defaultValue) {
+    return isBoolean() ? (Boolean) get() : defaultValue.get();
+  }
 
   /**
    * @return true if value of this instance is a {@link Boolean} instance

--- a/src/main/java/io/vertx/openapi/validation/Parameter.java
+++ b/src/main/java/io/vertx/openapi/validation/Parameter.java
@@ -26,14 +26,14 @@ interface Parameter {
    */
   @Nullable
   default String getString() {
-    return getStringOrDefault(() -> null);
+    return getString(() -> null);
   }
 
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link String} or is
    * null, otherwise it returns the value.
    */
-  default String getStringOrDefault(Supplier<String> defaultValue) {
+  default String getString(Supplier<String> defaultValue) {
     return isString() ? (String) get() : defaultValue.get();
   }
 
@@ -49,14 +49,14 @@ interface Parameter {
    */
   @Nullable
   default Integer getInteger() {
-    return getIntegerOrDefault(() -> null);
+    return getInteger(() -> null);
   }
 
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is
    * null, otherwise it returns the value.
    */
-  default Integer getIntegerOrDefault(Supplier<Integer> defaultValue) {
+  default Integer getInteger(Supplier<Integer> defaultValue) {
     return isNumber() ? Integer.valueOf(((Number) get()).intValue()) : defaultValue.get();
   }
 
@@ -65,14 +65,14 @@ interface Parameter {
    */
   @Nullable
   default Long getLong() {
-    return getLongOrDefault(() -> null);
+    return getLong(() -> null);
   }
 
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is
    * null, otherwise it returns the value.
    */
-  default Long getLongOrDefault(Supplier<Long> defaultValue) {
+  default Long getLong(Supplier<Long> defaultValue) {
     return isNumber() ? Long.valueOf(((Number) get()).longValue()) : defaultValue.get();
   }
 
@@ -97,14 +97,14 @@ interface Parameter {
    */
   @Nullable
   default Double getDouble() {
-    return getDoubleOrDefault(() -> null);
+    return getDouble(() -> null);
   }
 
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is
    * null, otherwise it returns the value.
    */
-  default Double getDoubleOrDefault(Supplier<Double> defaultValue) {
+  default Double getDouble(Supplier<Double> defaultValue) {
     return isNumber() ? Double.valueOf(((Number) get()).doubleValue()) : defaultValue.get();
   }
 
@@ -120,14 +120,14 @@ interface Parameter {
    */
   @Nullable
   default Boolean getBoolean() {
-    return getBooleanOrDefault(() -> null);
+    return getBoolean(() -> null);
   }
 
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Boolean} or is
    * null, otherwise it returns the value.
    */
-  default Boolean getBooleanOrDefault(Supplier<Boolean> defaultValue) {
+  default Boolean getBoolean(Supplier<Boolean> defaultValue) {
     return isBoolean() ? (Boolean) get() : defaultValue.get();
   }
 
@@ -143,14 +143,14 @@ interface Parameter {
    */
   @Nullable
   default JsonObject getJsonObject() {
-    return getJsonObjectOrDefault(() -> null);
+    return getJsonObject(() -> null);
   }
 
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is
    * null, otherwise it returns the value.
    */
-  default JsonObject getJsonObjectOrDefault(Supplier<JsonObject> defaultValue) {
+  default JsonObject getJsonObject(Supplier<JsonObject> defaultValue) {
     return isJsonObject() ? (JsonObject) get() : defaultValue.get();
   }
 
@@ -166,14 +166,14 @@ interface Parameter {
    */
   @Nullable
   default JsonArray getJsonArray() {
-    return getJsonArrayOrDefault(() -> null);
+    return getJsonArray(() -> null);
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonArray} or is
    * null, otherwise it returns the value.
    */
-  default JsonArray getJsonArrayOrDefault(Supplier<JsonArray> defaultValue) {
+  default JsonArray getJsonArray(Supplier<JsonArray> defaultValue) {
     return isJsonArray() ? (JsonArray) get() : defaultValue.get();
   }
 
@@ -189,14 +189,14 @@ interface Parameter {
    */
   @Nullable
   default Buffer getBuffer() {
-    return getBufferOrDefault(() -> null);
+    return getBuffer(() -> null);
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Buffer} or is
    * null, otherwise it returns the value.
    */
-  default Buffer getBufferOrDefault(Supplier<Buffer> defaultValue) {
+  default Buffer getBuffer(Supplier<Buffer> defaultValue) {
     return isBuffer() ? (Buffer) get() : defaultValue.get();
   }
 

--- a/src/main/java/io/vertx/openapi/validation/Parameter.java
+++ b/src/main/java/io/vertx/openapi/validation/Parameter.java
@@ -55,11 +55,7 @@ interface Parameter {
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
    */
   default Integer getIntegerOrDefault(Supplier<Integer> defaultValue) {
-    if(isNumber()) {
-      return ((Number) get()).intValue();
-    }
-
-    return defaultValue.get();
+    return isNumber() ? Integer.valueOf(((Number) get()).intValue()) : defaultValue.get();
   }
 
   /**
@@ -74,11 +70,7 @@ interface Parameter {
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
    */
   default Long getLongOrDefault(Supplier<Long> defaultValue) {
-    if(isNumber()) {
-      return ((Number) get()).longValue();
-    }
-
-    return defaultValue.get();
+    return isNumber() ? Long.valueOf(((Number) get()).longValue()) : defaultValue.get();
   }
 
   /**
@@ -93,11 +85,7 @@ interface Parameter {
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
    */
   default Float getFloatOrDefault(Supplier<Float> defaultValue) {
-    if(isNumber()) {
-      return ((Number) get()).floatValue();
-    }
-
-    return defaultValue.get();
+    return isNumber() ? Float.valueOf(((Number) get()).floatValue()) : defaultValue.get();
   }
 
   /**
@@ -112,11 +100,7 @@ interface Parameter {
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
    */
   default Double getDoubleOrDefault(Supplier<Double> defaultValue) {
-    if(isNumber()) {
-      return ((Number) get()).doubleValue();
-    }
-
-    return defaultValue.get();
+    return isNumber() ? Double.valueOf(((Number) get()).doubleValue()) : defaultValue.get();
   }
 
   /**

--- a/src/main/java/io/vertx/openapi/validation/Parameter.java
+++ b/src/main/java/io/vertx/openapi/validation/Parameter.java
@@ -47,7 +47,9 @@ interface Parameter {
    * @return null if value is not a {@link Number}, otherwise it returns value as {@link Integer}
    */
   @Nullable
-  default Integer getInteger() { return getIntegerOrDefault(() -> null); }
+  default Integer getInteger() {
+    return getIntegerOrDefault(() -> null);
+  }
 
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
@@ -64,7 +66,9 @@ interface Parameter {
    * @return null if value is not a {@link Number}, otherwise it returns value as {@link Long}
    */
   @Nullable
-  default Long getLong() { return getLongOrDefault(() -> null); }
+  default Long getLong() {
+    return getLongOrDefault(() -> null);
+  }
 
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
@@ -81,7 +85,9 @@ interface Parameter {
    * @return null if value is not a {@link Number}, otherwise it returns value as {@link Float}
    */
   @Nullable
-  default Float getFloat() { return getFloatOrDefault(() -> null); }
+  default Float getFloat() {
+    return getFloatOrDefault(() -> null);
+  }
 
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
@@ -98,7 +104,9 @@ interface Parameter {
    * @return null if value is not a {@link Number}, otherwise it returns value as {@link Double}
    */
   @Nullable
-  default Double getDouble() { return getDoubleOrDefault(() -> null); }
+  default Double getDouble() {
+    return getDoubleOrDefault(() -> null);
+  }
 
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
@@ -122,7 +130,9 @@ interface Parameter {
    * @return null if value is not a {@link Boolean}, otherwise it returns value
    */
   @Nullable
-  default Boolean getBoolean() { return getBooleanOrDefault(() -> null); }
+  default Boolean getBoolean() {
+    return getBooleanOrDefault(() -> null);
+  }
 
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Boolean} or is null, otherwise it returns the value.
@@ -147,7 +157,9 @@ interface Parameter {
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is null, otherwise it returns the value.
    */
-  default JsonObject getJsonObjectOrDefault(Supplier<JsonObject> defaultValue) { return isJsonObject() ? (JsonObject) get() : defaultValue.get(); }
+  default JsonObject getJsonObjectOrDefault(Supplier<JsonObject> defaultValue) {
+    return isJsonObject() ? (JsonObject) get() : defaultValue.get();
+  }
 
   /**
    * @return true if value of this instance is a {@link JsonObject} instance
@@ -167,7 +179,9 @@ interface Parameter {
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is null, otherwise it returns the value.
    */
-  default JsonArray getJsonArrayOrDefault(Supplier<JsonArray> defaultValue) { return isJsonArray() ? (JsonArray) get() : defaultValue.get(); }
+  default JsonArray getJsonArrayOrDefault(Supplier<JsonArray> defaultValue) {
+    return isJsonArray() ? (JsonArray) get() : defaultValue.get();
+  }
 
   /**
    * @return true if value of this instance is a {@link JsonArray} instance
@@ -187,7 +201,9 @@ interface Parameter {
   /**
    * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is null, otherwise it returns the value.
    */
-  default Buffer getBufferOrDefault(Supplier<Buffer> defaultValue) { return isBuffer() ? (Buffer) get() : defaultValue.get(); }
+  default Buffer getBufferOrDefault(Supplier<Buffer> defaultValue) {
+    return isBuffer() ? (Buffer) get() : defaultValue.get();
+  }
 
   /**
    * @return true if value of this instance is a {@link Buffer} instance

--- a/src/main/java/io/vertx/openapi/validation/Parameter.java
+++ b/src/main/java/io/vertx/openapi/validation/Parameter.java
@@ -18,23 +18,20 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-import java.util.function.Supplier;
-
 interface Parameter {
   /**
    * @return null if value is not a {@link String}, otherwise it returns value
    */
   @Nullable
   default String getString() {
-    return getString(() -> null);
+    return getString(null);
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link String} or is
-   * null, otherwise it returns the value.
+   * @return the default if value is not a {@link String} or is null, otherwise it returns the value.
    */
-  default String getString(Supplier<String> defaultValue) {
-    return isString() ? (String) get() : defaultValue.get();
+  default String getString(String defaultValue) {
+    return isString() ? (String) get() : defaultValue;
   }
 
   /**
@@ -49,15 +46,14 @@ interface Parameter {
    */
   @Nullable
   default Integer getInteger() {
-    return getInteger(() -> null);
+    return getInteger(null);
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is
-   * null, otherwise it returns the value.
+   * @return the default supplied if value is not a {@link Number} or is null, otherwise it returns the value.
    */
-  default Integer getInteger(Supplier<Integer> defaultValue) {
-    return isNumber() ? Integer.valueOf(((Number) get()).intValue()) : defaultValue.get();
+  default Integer getInteger(Integer defaultValue) {
+    return isNumber() ? Integer.valueOf(((Number) get()).intValue()) : defaultValue;
   }
 
   /**
@@ -65,15 +61,14 @@ interface Parameter {
    */
   @Nullable
   default Long getLong() {
-    return getLong(() -> null);
+    return getLong(null);
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is
-   * null, otherwise it returns the value.
+   * @return the default supplied if value is not a {@link Number} or is null, otherwise it returns the value.
    */
-  default Long getLong(Supplier<Long> defaultValue) {
-    return isNumber() ? Long.valueOf(((Number) get()).longValue()) : defaultValue.get();
+  default Long getLong(Long defaultValue) {
+    return isNumber() ? Long.valueOf(((Number) get()).longValue()) : defaultValue;
   }
 
   /**
@@ -81,15 +76,14 @@ interface Parameter {
    */
   @Nullable
   default Float getFloat() {
-    return getFloatOrDefault(() -> null);
+    return getFloatOrDefault(null);
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is
-   * null, otherwise it returns the value.
+   * @return the default supplied if value is not a {@link Number} or is null, otherwise it returns the value.
    */
-  default Float getFloatOrDefault(Supplier<Float> defaultValue) {
-    return isNumber() ? Float.valueOf(((Number) get()).floatValue()) : defaultValue.get();
+  default Float getFloatOrDefault(Float defaultValue) {
+    return isNumber() ? Float.valueOf(((Number) get()).floatValue()) : defaultValue;
   }
 
   /**
@@ -97,15 +91,14 @@ interface Parameter {
    */
   @Nullable
   default Double getDouble() {
-    return getDouble(() -> null);
+    return getDouble(null);
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is
-   * null, otherwise it returns the value.
+   * @return the default supplied if value is not a {@link Number} or is null, otherwise it returns the value.
    */
-  default Double getDouble(Supplier<Double> defaultValue) {
-    return isNumber() ? Double.valueOf(((Number) get()).doubleValue()) : defaultValue.get();
+  default Double getDouble(Double defaultValue) {
+    return isNumber() ? Double.valueOf(((Number) get()).doubleValue()) : defaultValue;
   }
 
   /**
@@ -120,15 +113,14 @@ interface Parameter {
    */
   @Nullable
   default Boolean getBoolean() {
-    return getBoolean(() -> null);
+    return getBoolean(null);
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Boolean} or is
-   * null, otherwise it returns the value.
+   * @return the default supplied if value is not a {@link Boolean} or is null, otherwise it returns the value.
    */
-  default Boolean getBoolean(Supplier<Boolean> defaultValue) {
-    return isBoolean() ? (Boolean) get() : defaultValue.get();
+  default Boolean getBoolean(Boolean defaultValue) {
+    return isBoolean() ? (Boolean) get() : defaultValue;
   }
 
   /**
@@ -143,15 +135,14 @@ interface Parameter {
    */
   @Nullable
   default JsonObject getJsonObject() {
-    return getJsonObject(() -> null);
+    return getJsonObject(null);
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is
-   * null, otherwise it returns the value.
+   * @return the default supplied if value is not a {@link JsonObject} or is null, otherwise it returns the value.
    */
-  default JsonObject getJsonObject(Supplier<JsonObject> defaultValue) {
-    return isJsonObject() ? (JsonObject) get() : defaultValue.get();
+  default JsonObject getJsonObject(JsonObject defaultValue) {
+    return isJsonObject() ? (JsonObject) get() : defaultValue;
   }
 
   /**
@@ -166,15 +157,14 @@ interface Parameter {
    */
   @Nullable
   default JsonArray getJsonArray() {
-    return getJsonArray(() -> null);
+    return getJsonArray(null);
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonArray} or is
-   * null, otherwise it returns the value.
+   * @return the default supplied if value is not a {@link JsonArray} or is null, otherwise it returns the value.
    */
-  default JsonArray getJsonArray(Supplier<JsonArray> defaultValue) {
-    return isJsonArray() ? (JsonArray) get() : defaultValue.get();
+  default JsonArray getJsonArray(JsonArray defaultValue) {
+    return isJsonArray() ? (JsonArray) get() : defaultValue;
   }
 
   /**
@@ -189,15 +179,14 @@ interface Parameter {
    */
   @Nullable
   default Buffer getBuffer() {
-    return getBuffer(() -> null);
+    return getBuffer(null);
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Buffer} or is
-   * null, otherwise it returns the value.
+   * @return the default suppliedif value is not a {@link Buffer} or is null, otherwise it returns the value.
    */
-  default Buffer getBuffer(Supplier<Buffer> defaultValue) {
-    return isBuffer() ? (Buffer) get() : defaultValue.get();
+  default Buffer getBuffer(Buffer defaultValue) {
+    return isBuffer() ? (Buffer) get() : defaultValue;
   }
 
   /**

--- a/src/main/java/io/vertx/openapi/validation/Parameter.java
+++ b/src/main/java/io/vertx/openapi/validation/Parameter.java
@@ -18,13 +18,22 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.util.function.Supplier;
+
 interface Parameter {
   /**
    * @return null if value is not a {@link String}, otherwise it returns value
    */
   @Nullable
   default String getString() {
-    return isString() ? (String) get() : null;
+    return getStringOrDefault(() -> null);
+  }
+
+  /**
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link String} or is null, otherwise it returns the value.
+   */
+  default String getStringOrDefault(Supplier<String> defaultValue) {
+    return isString() ? (String) get() : defaultValue.get();
   }
 
   /**
@@ -38,32 +47,68 @@ interface Parameter {
    * @return null if value is not a {@link Number}, otherwise it returns value as {@link Integer}
    */
   @Nullable
-  default Integer getInteger() {
-    return isNumber() ? ((Number) get()).intValue() : null;
+  default Integer getInteger() { return getIntegerOrDefault(() -> null); }
+
+  /**
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
+   */
+  default Integer getIntegerOrDefault(Supplier<Integer> defaultValue) {
+    if(isNumber()) {
+      return ((Number) get()).intValue();
+    }
+
+    return defaultValue.get();
   }
 
   /**
    * @return null if value is not a {@link Number}, otherwise it returns value as {@link Long}
    */
   @Nullable
-  default Long getLong() {
-    return isNumber() ? ((Number) get()).longValue() : null;
+  default Long getLong() { return getLongOrDefault(() -> null); }
+
+  /**
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
+   */
+  default Long getLongOrDefault(Supplier<Long> defaultValue) {
+    if(isNumber()) {
+      return ((Number) get()).longValue();
+    }
+
+    return defaultValue.get();
   }
 
   /**
    * @return null if value is not a {@link Number}, otherwise it returns value as {@link Float}
    */
   @Nullable
-  default Float getFloat() {
-    return isNumber() ? ((Number) get()).floatValue() : null;
+  default Float getFloat() { return getFloatOrDefault(() -> null); }
+
+  /**
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
+   */
+  default Float getFloatOrDefault(Supplier<Float> defaultValue) {
+    if(isNumber()) {
+      return ((Number) get()).floatValue();
+    }
+
+    return defaultValue.get();
   }
 
   /**
    * @return null if value is not a {@link Number}, otherwise it returns value as {@link Double}
    */
   @Nullable
-  default Double getDouble() {
-    return isNumber() ? ((Number) get()).doubleValue() : null;
+  default Double getDouble() { return getDoubleOrDefault(() -> null); }
+
+  /**
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
+   */
+  default Double getDoubleOrDefault(Supplier<Double> defaultValue) {
+    if(isNumber()) {
+      return ((Number) get()).doubleValue();
+    }
+
+    return defaultValue.get();
   }
 
   /**
@@ -77,9 +122,12 @@ interface Parameter {
    * @return null if value is not a {@link Boolean}, otherwise it returns value
    */
   @Nullable
-  default Boolean getBoolean() {
-    return isBoolean() ? (Boolean) get() : null;
-  }
+  default Boolean getBoolean() { return getBooleanOrDefault(() -> null); }
+
+  /**
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Boolean} or is null, otherwise it returns the value.
+   */
+  default Boolean getBooleanOrDefault(Supplier<Boolean> defaultValue) { return isBoolean() ? (Boolean) get() : defaultValue.get(); }
 
   /**
    * @return true if value of this instance is a {@link Boolean} instance
@@ -93,8 +141,13 @@ interface Parameter {
    */
   @Nullable
   default JsonObject getJsonObject() {
-    return isJsonObject() ? (JsonObject) get() : null;
+    return getJsonObjectOrDefault(() -> null);
   }
+
+  /**
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is null, otherwise it returns the value.
+   */
+  default JsonObject getJsonObjectOrDefault(Supplier<JsonObject> defaultValue) { return isJsonObject() ? (JsonObject) get() : defaultValue.get(); }
 
   /**
    * @return true if value of this instance is a {@link JsonObject} instance
@@ -108,8 +161,13 @@ interface Parameter {
    */
   @Nullable
   default JsonArray getJsonArray() {
-    return isJsonArray() ? (JsonArray) get() : null;
+    return getJsonArrayOrDefault(() -> null);
   }
+
+  /**
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is null, otherwise it returns the value.
+   */
+  default JsonArray getJsonArrayOrDefault(Supplier<JsonArray> defaultValue) { return isJsonArray() ? (JsonArray) get() : defaultValue.get(); }
 
   /**
    * @return true if value of this instance is a {@link JsonArray} instance
@@ -123,8 +181,13 @@ interface Parameter {
    */
   @Nullable
   default Buffer getBuffer() {
-    return isBuffer() ? (Buffer) get() : null;
+    return getBufferOrDefault(() -> null);
   }
+
+  /**
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is null, otherwise it returns the value.
+   */
+  default Buffer getBufferOrDefault(Supplier<Buffer> defaultValue) { return isBuffer() ? (Buffer) get() : defaultValue.get(); }
 
   /**
    * @return true if value of this instance is a {@link Buffer} instance

--- a/src/main/java/io/vertx/openapi/validation/Parameter.java
+++ b/src/main/java/io/vertx/openapi/validation/Parameter.java
@@ -30,7 +30,8 @@ interface Parameter {
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link String} or is null, otherwise it returns the value.
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link String} or is
+   * null, otherwise it returns the value.
    */
   default String getStringOrDefault(Supplier<String> defaultValue) {
     return isString() ? (String) get() : defaultValue.get();
@@ -52,7 +53,8 @@ interface Parameter {
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is
+   * null, otherwise it returns the value.
    */
   default Integer getIntegerOrDefault(Supplier<Integer> defaultValue) {
     return isNumber() ? Integer.valueOf(((Number) get()).intValue()) : defaultValue.get();
@@ -67,7 +69,8 @@ interface Parameter {
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is
+   * null, otherwise it returns the value.
    */
   default Long getLongOrDefault(Supplier<Long> defaultValue) {
     return isNumber() ? Long.valueOf(((Number) get()).longValue()) : defaultValue.get();
@@ -82,7 +85,8 @@ interface Parameter {
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is
+   * null, otherwise it returns the value.
    */
   default Float getFloatOrDefault(Supplier<Float> defaultValue) {
     return isNumber() ? Float.valueOf(((Number) get()).floatValue()) : defaultValue.get();
@@ -97,7 +101,8 @@ interface Parameter {
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is null, otherwise it returns the value.
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Number} or is
+   * null, otherwise it returns the value.
    */
   default Double getDoubleOrDefault(Supplier<Double> defaultValue) {
     return isNumber() ? Double.valueOf(((Number) get()).doubleValue()) : defaultValue.get();
@@ -119,7 +124,8 @@ interface Parameter {
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Boolean} or is null, otherwise it returns the value.
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link Boolean} or is
+   * null, otherwise it returns the value.
    */
   default Boolean getBooleanOrDefault(Supplier<Boolean> defaultValue) {
     return isBoolean() ? (Boolean) get() : defaultValue.get();
@@ -141,7 +147,8 @@ interface Parameter {
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is null, otherwise it returns the value.
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is
+   * null, otherwise it returns the value.
    */
   default JsonObject getJsonObjectOrDefault(Supplier<JsonObject> defaultValue) {
     return isJsonObject() ? (JsonObject) get() : defaultValue.get();
@@ -163,7 +170,8 @@ interface Parameter {
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is null, otherwise it returns the value.
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is
+   * null, otherwise it returns the value.
    */
   default JsonArray getJsonArrayOrDefault(Supplier<JsonArray> defaultValue) {
     return isJsonArray() ? (JsonArray) get() : defaultValue.get();
@@ -185,7 +193,8 @@ interface Parameter {
   }
 
   /**
-   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is null, otherwise it returns the value.
+   * @return the default supplied by a {@link java.util.function.Supplier} if value is not a {@link JsonObject} or is
+   * null, otherwise it returns the value.
    */
   default Buffer getBufferOrDefault(Supplier<Buffer> defaultValue) {
     return isBuffer() ? (Buffer) get() : defaultValue.get();

--- a/src/main/java/io/vertx/openapi/validation/Parameter.java
+++ b/src/main/java/io/vertx/openapi/validation/Parameter.java
@@ -76,13 +76,13 @@ interface Parameter {
    */
   @Nullable
   default Float getFloat() {
-    return getFloatOrDefault(null);
+    return getFloat(null);
   }
 
   /**
    * @return the default supplied if value is not a {@link Number} or is null, otherwise it returns the value.
    */
-  default Float getFloatOrDefault(Float defaultValue) {
+  default Float getFloat(Float defaultValue) {
     return isNumber() ? Float.valueOf(((Number) get()).floatValue()) : defaultValue;
   }
 

--- a/src/test/java/io/vertx/openapi/validation/ParameterTest.java
+++ b/src/test/java/io/vertx/openapi/validation/ParameterTest.java
@@ -20,8 +20,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.stream.Stream;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/src/test/java/io/vertx/openapi/validation/ParameterTest.java
+++ b/src/test/java/io/vertx/openapi/validation/ParameterTest.java
@@ -154,15 +154,15 @@ class ParameterTest {
     DummyParameter parameter = new DummyParameter().setValue(value);
 
     Object[] results = new Object[9];
-    results[0] = parameter.getStringOrDefault(() -> "myDefaultString");
-    results[1] = parameter.getBooleanOrDefault(() -> false);
-    results[2] = parameter.getJsonObjectOrDefault(() -> DEFAULT_JSON_OBJECT);
-    results[3] = parameter.getJsonArrayOrDefault(() -> DEFAULT_JSON_ARRAY);
-    results[4] = parameter.getBufferOrDefault(DEFAULT_JSON_OBJECT::toBuffer);
-    results[5] = parameter.getIntegerOrDefault(() -> 8008);
-    results[6] = parameter.getLongOrDefault(() -> 8008L);
+    results[0] = parameter.getString(() -> "myDefaultString");
+    results[1] = parameter.getBoolean(() -> false);
+    results[2] = parameter.getJsonObject(() -> DEFAULT_JSON_OBJECT);
+    results[3] = parameter.getJsonArray(() -> DEFAULT_JSON_ARRAY);
+    results[4] = parameter.getBuffer(DEFAULT_JSON_OBJECT::toBuffer);
+    results[5] = parameter.getInteger(() -> 8008);
+    results[6] = parameter.getLong(() -> 8008L);
     results[7] = parameter.getFloatOrDefault(() -> 8008.0f);
-    results[8] = parameter.getDoubleOrDefault(() -> 8008.0);
+    results[8] = parameter.getDouble(() -> 8008.0);
 
     for (int i = 0; i < 8; i++) {
       assertThat(results[i]).isEqualTo(expected[i]);

--- a/src/test/java/io/vertx/openapi/validation/ParameterTest.java
+++ b/src/test/java/io/vertx/openapi/validation/ParameterTest.java
@@ -154,15 +154,15 @@ class ParameterTest {
     DummyParameter parameter = new DummyParameter().setValue(value);
 
     Object[] results = new Object[9];
-    results[0] = parameter.getString(() -> "myDefaultString");
-    results[1] = parameter.getBoolean(() -> false);
-    results[2] = parameter.getJsonObject(() -> DEFAULT_JSON_OBJECT);
-    results[3] = parameter.getJsonArray(() -> DEFAULT_JSON_ARRAY);
-    results[4] = parameter.getBuffer(DEFAULT_JSON_OBJECT::toBuffer);
-    results[5] = parameter.getInteger(() -> 8008);
-    results[6] = parameter.getLong(() -> 8008L);
-    results[7] = parameter.getFloatOrDefault(() -> 8008.0f);
-    results[8] = parameter.getDouble(() -> 8008.0);
+    results[0] = parameter.getString("myDefaultString");
+    results[1] = parameter.getBoolean(false);
+    results[2] = parameter.getJsonObject(DEFAULT_JSON_OBJECT);
+    results[3] = parameter.getJsonArray(DEFAULT_JSON_ARRAY);
+    results[4] = parameter.getBuffer(DEFAULT_JSON_OBJECT.toBuffer());
+    results[5] = parameter.getInteger(8008);
+    results[6] = parameter.getLong(8008L);
+    results[7] = parameter.getFloatOrDefault(8008.0f);
+    results[8] = parameter.getDouble(8008.0d);
 
     for (int i = 0; i < 8; i++) {
       assertThat(results[i]).isEqualTo(expected[i]);

--- a/src/test/java/io/vertx/openapi/validation/ParameterTest.java
+++ b/src/test/java/io/vertx/openapi/validation/ParameterTest.java
@@ -161,7 +161,7 @@ class ParameterTest {
     results[4] = parameter.getBuffer(DEFAULT_JSON_OBJECT.toBuffer());
     results[5] = parameter.getInteger(8008);
     results[6] = parameter.getLong(8008L);
-    results[7] = parameter.getFloatOrDefault(8008.0f);
+    results[7] = parameter.getFloat(8008.0f);
     results[8] = parameter.getDouble(8008.0d);
 
     for (int i = 0; i < 8; i++) {

--- a/src/test/java/io/vertx/openapi/validation/ParameterTest.java
+++ b/src/test/java/io/vertx/openapi/validation/ParameterTest.java
@@ -19,6 +19,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -26,6 +29,9 @@ import static io.vertx.openapi.impl.Utils.EMPTY_JSON_ARRAY;
 import static io.vertx.openapi.impl.Utils.EMPTY_JSON_OBJECT;
 
 class ParameterTest {
+
+  private static final JsonArray DEFAULT_JSON_ARRAY = new JsonArray(Arrays.asList("a", "b", "c"));
+  public static final JsonObject DEFAULT_JSON_OBJECT = new JsonObject().put("abc", "123");
 
   private static Stream<Arguments> provideValueTypes() {
     Boolean[] isNumber = new Boolean[] {false, true, false, false, false, false, false, false};
@@ -77,6 +83,30 @@ class ParameterTest {
     );
   }
 
+  private static Stream<Arguments> provideAllNullValues() {
+    Object[] stringResult = new Object[] {"myString", false, DEFAULT_JSON_OBJECT, DEFAULT_JSON_ARRAY, DEFAULT_JSON_OBJECT.toBuffer(), 8008, 8008L, 8008.0f, 8008.0};
+    Object[] booleanResult = new Object[] {"myDefaultString", true, DEFAULT_JSON_OBJECT, DEFAULT_JSON_ARRAY, DEFAULT_JSON_OBJECT.toBuffer(), 8008, 8008L, 8008.0f, 8008.0};
+    Object[] jsonObjectResult = new Object[] {"myDefaultString", false, EMPTY_JSON_OBJECT, DEFAULT_JSON_ARRAY, DEFAULT_JSON_OBJECT.toBuffer(), 8008, 8008L, 8008.0f, 8008.0};
+    Object[] jsonArrayResult = new Object[] {"myDefaultString", false, DEFAULT_JSON_OBJECT, EMPTY_JSON_ARRAY, DEFAULT_JSON_OBJECT.toBuffer(), 8008, 8008L, 8008.0f, 8008.0};
+    Object[] bufferResult = new Object[] {"myDefaultString", false, DEFAULT_JSON_OBJECT, DEFAULT_JSON_ARRAY, Buffer.buffer(), 8008, 8008L, 8008.0f, 8008.0};
+    Object[] intResult = new Object[] {"myDefaultString", false, DEFAULT_JSON_OBJECT, DEFAULT_JSON_ARRAY, DEFAULT_JSON_OBJECT.toBuffer(), 1337, 1337L, 1337.0f, 1337.0,};
+    Object[] longResult = new Object[] {"myDefaultString", false, DEFAULT_JSON_OBJECT, DEFAULT_JSON_ARRAY, DEFAULT_JSON_OBJECT.toBuffer(), 42, 42L, 42.0f, 42.0};
+    Object[] floatResult = new Object[] {"myDefaultString", false, DEFAULT_JSON_OBJECT, DEFAULT_JSON_ARRAY, DEFAULT_JSON_OBJECT.toBuffer(), 13, 13, 13.37f, 13.37};
+    Object[] doubleResult = new Object[] {"myDefaultString", false, DEFAULT_JSON_OBJECT, DEFAULT_JSON_ARRAY, DEFAULT_JSON_OBJECT.toBuffer(), 4, 4L, 4.2f, 4.2};
+
+    return Stream.of(
+      Arguments.of("String", "myString", stringResult),
+      Arguments.of("Boolean", true, booleanResult),
+      Arguments.of("JsonObject", EMPTY_JSON_OBJECT, jsonObjectResult),
+      Arguments.of("JsonArray", EMPTY_JSON_ARRAY, jsonArrayResult),
+      Arguments.of("Buffer (empty)", Buffer.buffer(), bufferResult),
+      Arguments.of("Integer", 1337, intResult),
+      Arguments.of("Long", 42L, longResult),
+      Arguments.of("Float", 13.37f, floatResult),
+      Arguments.of("Double", 4.2, doubleResult)
+    );
+  }
+
   @ParameterizedTest(name = "{index} test if value is of type {0}")
   @MethodSource("provideValueTypes")
   void testIsMethods(String type, Object value, Boolean[] expected) {
@@ -110,6 +140,31 @@ class ParameterTest {
     results[6] = parameter.getLong();
     results[7] = parameter.getFloat();
     results[8] = parameter.getDouble();
+
+    for (int i = 0; i < 8; i++) {
+      assertThat(results[i]).isEqualTo(expected[i]);
+    }
+    if (expected[8] != null) {
+      Double expectedDouble = (Double) expected[8];
+      assertThat((Double) results[8]).isWithin(0.1).of(expectedDouble);
+    }
+  }
+
+  @ParameterizedTest(name = "{index} test default getters with value of type {0}")
+  @MethodSource("provideAllNullValues")
+  void testDefaultGetters(String type, Object value, Object[] expected) {
+    DummyParameter parameter = new DummyParameter().setValue(value);
+
+    Object[] results = new Object[9];
+    results[0] = parameter.getStringOrDefault(() -> "myDefaultString");
+    results[1] = parameter.getBooleanOrDefault(() -> false);
+    results[2] = parameter.getJsonObjectOrDefault(() -> DEFAULT_JSON_OBJECT);
+    results[3] = parameter.getJsonArrayOrDefault(() -> DEFAULT_JSON_ARRAY);
+    results[4] = parameter.getBufferOrDefault(DEFAULT_JSON_OBJECT::toBuffer);
+    results[5] = parameter.getIntegerOrDefault(() -> 8008);
+    results[6] = parameter.getLongOrDefault(() -> 8008L);
+    results[7] = parameter.getFloatOrDefault(() -> 8008.0f);
+    results[8] = parameter.getDoubleOrDefault(() -> 8008.0);
 
     for (int i = 0; i < 8; i++) {
       assertThat(results[i]).isEqualTo(expected[i]);


### PR DESCRIPTION
Motivation:

As described in https://github.com/eclipse-vertx/vertx-openapi/issues/14 it can be quite cumbersome to always check if a default parameter is null and using some default if it is. Instead now there are convenience functions that take in a supplier so that if the value is null (or not of the expected type), it will return the default value you supplied.

So now instead of having to write:
```
RequestParameter myList = validatedRequest.getQuery().get("myList");
List<String> list = myList.isNull() ? List.of() : myList .getJsonArray().getList();
```
you can now write:
```
RequestParameter myList = validatedRequest.getQuery().get("myList");
List<String> list = myList.getJsonArray(new JsonArray()).getList();
```

and not have to worry about your default parameter being null anymore.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md ✅ 
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines ✅ 
