### PR TITLE
feat: Adding application/hal+json support.

### DIFF
--- a/src/main/java/io/vertx/openapi/contract/MediaType.java
+++ b/src/main/java/io/vertx/openapi/contract/MediaType.java
@@ -29,10 +29,11 @@ import java.util.List;
 @VertxGen
 public interface MediaType extends OpenAPIObject {
 
+  String APPLICATION_HAL_JSON = "application/hal+json";
   String APPLICATION_JSON = HttpHeaderValues.APPLICATION_JSON.toString();
   String APPLICATION_JSON_UTF8 = APPLICATION_JSON + "; charset=utf-8";
   String MULTIPART_FORM_DATA = HttpHeaderValues.MULTIPART_FORM_DATA.toString();
-  List<String> SUPPORTED_MEDIA_TYPES = Arrays.asList(APPLICATION_JSON, APPLICATION_JSON_UTF8, MULTIPART_FORM_DATA);
+  List<String> SUPPORTED_MEDIA_TYPES = Arrays.asList(APPLICATION_JSON, APPLICATION_JSON_UTF8, MULTIPART_FORM_DATA, APPLICATION_HAL_JSON);
 
   static boolean isMediaTypeSupported(String type) {
     return SUPPORTED_MEDIA_TYPES.contains(type.toLowerCase());

--- a/src/main/java/io/vertx/openapi/validation/impl/BaseValidator.java
+++ b/src/main/java/io/vertx/openapi/validation/impl/BaseValidator.java
@@ -14,6 +14,7 @@ package io.vertx.openapi.validation.impl;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.openapi.contract.MediaType;
 import io.vertx.openapi.contract.OpenAPIContract;
 import io.vertx.openapi.contract.Operation;
 import io.vertx.openapi.validation.transformer.ApplicationJsonTransformer;
@@ -41,6 +42,7 @@ class BaseValidator {
     bodyTransformers = new HashMap<>();
     bodyTransformers.put(APPLICATION_JSON.toString(), new ApplicationJsonTransformer());
     bodyTransformers.put(MULTIPART_FORM_DATA.toString(), new MultipartFormTransformer());
+    bodyTransformers.put(MediaType.APPLICATION_HAL_JSON, new ApplicationJsonTransformer());
   }
 
   // VisibleForTesting

--- a/src/test/java/io/vertx/openapi/contract/impl/RequestBodyImplTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/RequestBodyImplTest.java
@@ -76,7 +76,7 @@ class RequestBodyImplTest {
       Arguments.of("0002_RequestBody_With_Content_Type_Text_Plain", UNSUPPORTED_FEATURE,
         "The passed OpenAPI contract contains a feature that is not supported: Operation dummyOperation defines a " +
           "request body with an unsupported media type. Supported: application/json, application/json; charset=utf-8," +
-          " multipart/form-data")
+          " multipart/form-data, application/hal+json")
     );
   }
 

--- a/src/test/java/io/vertx/openapi/contract/impl/ResponseImplTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/ResponseImplTest.java
@@ -68,7 +68,7 @@ class ResponseImplTest {
       Arguments.of("0000_Response_With_Content_Type_Text_Plain", UNSUPPORTED_FEATURE,
         "The passed OpenAPI contract contains a feature that is not supported: Operation dummyOperation defines a " +
           "response with an unsupported media type. Supported: application/json, application/json; charset=utf-8, " +
-          "multipart/form-data")
+          "multipart/form-data, application/hal+json")
     );
   }
 

--- a/src/test/java/io/vertx/openapi/validation/impl/BaseValidatorTest.java
+++ b/src/test/java/io/vertx/openapi/validation/impl/BaseValidatorTest.java
@@ -22,6 +22,8 @@ import io.vertx.openapi.validation.ValidatorException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
@@ -57,4 +59,11 @@ class BaseValidatorTest {
       testContext.completeNow();
     })).onSuccess(v -> testContext.failNow("Test expects a failure"));
   }
+
+  @ParameterizedTest(name = "{index} Test valid if {0} is a valid base transformer.")
+  @ValueSource(strings = { "application/json", "application/hal+json" })
+  public void testValidBaseTransformer(String transformer) {
+    assertThat(validator.bodyTransformers.containsKey(transformer)).isTrue();
+  }
+
 }


### PR DESCRIPTION
Motivation:

As described in https://github.com/eclipse-vertx/vertx-openapi/issues/59, we want to support the application/hal+json media type. This was previously supported in vertx-web-api-contract so this is to add parity. application/hal+json and application/json can use the same body transformer as they are both JSON types.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
