### PR TITLE
fix: make Parameter in validation package public

### DIFF
--- a/src/main/java/io/vertx/openapi/validation/Parameter.java
+++ b/src/main/java/io/vertx/openapi/validation/Parameter.java
@@ -18,7 +18,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-interface Parameter {
+public interface Parameter {
   /**
    * @return null if value is not a {@link String}, otherwise it returns value
    */


### PR DESCRIPTION
This is required to generate mutiny bindings.

see #69 
