### PR TITLE
Update Utils.java, add Yaml string to JsonObject

### DIFF
--- a/src/main/java/io/vertx/openapi/impl/Utils.java
+++ b/src/main/java/io/vertx/openapi/impl/Utils.java
@@ -48,13 +48,7 @@ public final class Utils {
       if ("json".equals(suffix)) {
         return succeededFuture(buff.toJsonObject());
       } else if ("yaml".equals(suffix) || "yml".equals(suffix)) {
-        try {
-          final Yaml yaml = new Yaml(new OpenAPIYamlConstructor());
-          Map<Object, Object> doc = yaml.load(buff.toString(StandardCharsets.UTF_8));
-          return succeededFuture(new JsonObject(jsonify(doc)));
-        } catch (RuntimeException e) {
-          return failedFuture(e);
-        }
+        return yamlStringToJson((buff.toString(StandardCharsets.UTF_8));
       } else {
         return failedFuture(new IllegalArgumentException("Only JSON or YAML files are allowed"));
       }

--- a/src/main/java/io/vertx/openapi/impl/Utils.java
+++ b/src/main/java/io/vertx/openapi/impl/Utils.java
@@ -61,6 +61,22 @@ public final class Utils {
     });
   }
 
+    /**
+   * Reads YAML string and transforms it into a JsonObject.
+   *
+   * @param path  The yamlString proper YAML formatted STring
+   * @return A succeeded Future holding the JsonObject, or a failed Future if the file could not be parsed.
+   */
+  public static Future<JsonObject> yamlStringToJson(String yamlString) {
+    try {
+      final Yaml yaml = new Yaml(new OpenAPIYamlConstructor());
+      Map<Object, Object> doc = yaml.load(yamlString);
+      return succeededFuture(new JsonObject(jsonify(doc)));
+    } catch (RuntimeException e) {
+      return failedFuture(e);
+    }
+  }
+
   /**
    * Yaml allows map keys of type object, however json always requires key as String,
    * this helper method will ensure we adapt keys to the right type


### PR DESCRIPTION
Motivation:

We load Yaml from "elsewhere", not the file system. Instead of overloading the OpenAPIContract.from method, just add an utility method to turn a YAML string into a JsonObject to feed into from.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
