### PR TITLE
WIP: Implement support for application/octet-stream

### DIFF
--- a/src/main/java/io/vertx/openapi/contract/MediaType.java
+++ b/src/main/java/io/vertx/openapi/contract/MediaType.java
@@ -32,8 +32,10 @@ public interface MediaType extends OpenAPIObject {
   String APPLICATION_HAL_JSON = "application/hal+json";
   String APPLICATION_JSON = HttpHeaderValues.APPLICATION_JSON.toString();
   String APPLICATION_JSON_UTF8 = APPLICATION_JSON + "; charset=utf-8";
+  String APPLICATION_OCTET_STREAM = HttpHeaderValues.APPLICATION_OCTET_STREAM.toString();
   String MULTIPART_FORM_DATA = HttpHeaderValues.MULTIPART_FORM_DATA.toString();
-  List<String> SUPPORTED_MEDIA_TYPES = Arrays.asList(APPLICATION_JSON, APPLICATION_JSON_UTF8, MULTIPART_FORM_DATA, APPLICATION_HAL_JSON);
+  List<String> SUPPORTED_MEDIA_TYPES = Arrays.asList(APPLICATION_JSON, APPLICATION_JSON_UTF8,
+    MULTIPART_FORM_DATA, APPLICATION_HAL_JSON, APPLICATION_OCTET_STREAM);
 
   static boolean isMediaTypeSupported(String type) {
     return SUPPORTED_MEDIA_TYPES.contains(type.toLowerCase());

--- a/src/main/java/io/vertx/openapi/contract/impl/MediaTypeImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/MediaTypeImpl.java
@@ -30,7 +30,15 @@ public class MediaTypeImpl implements MediaType {
     this.mediaTypeModel = mediaTypeModel;
     JsonObject schemaJson = mediaTypeModel.getJsonObject(KEY_SCHEMA);
     if (schemaJson == null || schemaJson.isEmpty()) {
-      throw createUnsupportedFeature("Media Type without a schema");
+      // Inject default value if schema is left out
+      // by using shortcut "application/octet-stream: {}"
+      if (identifier.equalsIgnoreCase(MediaType.APPLICATION_OCTET_STREAM)) {
+        schemaJson = new JsonObject()
+          .put("type", "string")
+          .put("format", "binary");
+      } else {
+        throw createUnsupportedFeature("Media Type without a schema");
+      }
     }
     schema = JsonSchema.of(schemaJson);
   }

--- a/src/main/java/io/vertx/openapi/contract/impl/MediaTypeImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/MediaTypeImpl.java
@@ -32,10 +32,18 @@ public class MediaTypeImpl implements MediaType {
     if (schemaJson == null || schemaJson.isEmpty()) {
       // Inject default value if schema is left out
       // by using shortcut "application/octet-stream: {}"
+      // See https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0
       if (identifier.equalsIgnoreCase(MediaType.APPLICATION_OCTET_STREAM)) {
+        // In OpenAPI v3.0, describing file uploads is signalled with a type:
+        // string and the format set to byte, binary, or base64.
+        // In OpenAPI v3.1, JSON Schema helps make this far more clear with
+        // its contentEncoding and contentMediaType keywords,
+        // which are designed for exactly this sort of use.
+        // See https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-8.6
         schemaJson = new JsonObject()
           .put("type", "string")
-          .put("format", "binary");
+          .put("format", "binary")
+          .put("contentMediaType", "application/octet-stream");
       } else {
         throw createUnsupportedFeature("Media Type without a schema");
       }

--- a/src/main/java/io/vertx/openapi/validation/impl/BaseValidator.java
+++ b/src/main/java/io/vertx/openapi/validation/impl/BaseValidator.java
@@ -18,6 +18,7 @@ import io.vertx.openapi.contract.MediaType;
 import io.vertx.openapi.contract.OpenAPIContract;
 import io.vertx.openapi.contract.Operation;
 import io.vertx.openapi.validation.transformer.ApplicationJsonTransformer;
+import io.vertx.openapi.validation.transformer.ApplicationOctetStreamTransformer;
 import io.vertx.openapi.validation.transformer.BodyTransformer;
 import io.vertx.openapi.validation.transformer.MultipartFormTransformer;
 
@@ -42,6 +43,7 @@ class BaseValidator {
     bodyTransformers.put(MediaType.APPLICATION_JSON_UTF8, new ApplicationJsonTransformer());
     bodyTransformers.put(MediaType.MULTIPART_FORM_DATA, new MultipartFormTransformer());
     bodyTransformers.put(MediaType.APPLICATION_HAL_JSON, new ApplicationJsonTransformer());
+    bodyTransformers.put(MediaType.APPLICATION_OCTET_STREAM, new ApplicationOctetStreamTransformer());
   }
 
   // VisibleForTesting

--- a/src/main/java/io/vertx/openapi/validation/transformer/ApplicationOctetStreamTransformer.java
+++ b/src/main/java/io/vertx/openapi/validation/transformer/ApplicationOctetStreamTransformer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024, Lucimber UG
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation.transformer;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.openapi.contract.MediaType;
+import io.vertx.openapi.validation.ValidatableRequest;
+import io.vertx.openapi.validation.ValidatableResponse;
+import io.vertx.openapi.validation.ValidatorException;
+
+import static io.vertx.openapi.contract.MediaType.APPLICATION_OCTET_STREAM;
+import static io.vertx.openapi.validation.ValidatorErrorType.MISSING_REQUIRED_PARAMETER;
+
+public class ApplicationOctetStreamTransformer implements BodyTransformer {
+
+  @Override
+  public Object transformRequest(MediaType type, ValidatableRequest request) {
+    return transform(type, request.getBody().getBuffer(), request.getContentType(), "request");
+  }
+
+  @Override
+  public Object transformResponse(MediaType type, ValidatableResponse response) {
+    return transform(type, response.getBody().getBuffer(), response.getContentType(), "response");
+  }
+
+  private Object transform(MediaType type, Buffer body, String contentType,
+                           String responseOrRequest) {
+    if (contentType == null || contentType.isEmpty()
+      || !contentType.equalsIgnoreCase(APPLICATION_OCTET_STREAM)) {
+      String msg = "The " + responseOrRequest
+        + " doesn't contain the required content-type header application/octet-stream.";
+      throw new ValidatorException(msg, MISSING_REQUIRED_PARAMETER);
+    }
+    return body;
+  }
+}

--- a/src/test/java/io/vertx/openapi/contract/impl/RequestBodyImplTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/RequestBodyImplTest.java
@@ -76,7 +76,7 @@ class RequestBodyImplTest {
       Arguments.of("0002_RequestBody_With_Content_Type_Text_Plain", UNSUPPORTED_FEATURE,
         "The passed OpenAPI contract contains a feature that is not supported: Operation dummyOperation defines a " +
           "request body with an unsupported media type. Supported: application/json, application/json; charset=utf-8," +
-          " multipart/form-data, application/hal+json")
+          " multipart/form-data, application/hal+json, application/octet-stream")
     );
   }
 

--- a/src/test/java/io/vertx/openapi/contract/impl/ResponseImplTest.java
+++ b/src/test/java/io/vertx/openapi/contract/impl/ResponseImplTest.java
@@ -68,7 +68,7 @@ class ResponseImplTest {
       Arguments.of("0000_Response_With_Content_Type_Text_Plain", UNSUPPORTED_FEATURE,
         "The passed OpenAPI contract contains a feature that is not supported: Operation dummyOperation defines a " +
           "response with an unsupported media type. Supported: application/json, application/json; charset=utf-8, " +
-          "multipart/form-data, application/hal+json")
+          "multipart/form-data, application/hal+json, application/octet-stream")
     );
   }
 

--- a/src/test/java/io/vertx/openapi/validation/transformer/ApplicationOctetStreamTransformerTest.java
+++ b/src/test/java/io/vertx/openapi/validation/transformer/ApplicationOctetStreamTransformerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024, Lucimber UG
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.validation.transformer;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.openapi.validation.ValidatableRequest;
+import io.vertx.openapi.validation.ValidatableResponse;
+import io.vertx.openapi.validation.ValidatorException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
+import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_OCTET_STREAM;
+import static io.vertx.openapi.MockHelper.mockValidatableRequest;
+import static io.vertx.openapi.validation.ValidatorErrorType.MISSING_REQUIRED_PARAMETER;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ApplicationOctetStreamTransformerTest {
+  private final BodyTransformer transformer = new ApplicationOctetStreamTransformer();
+  private final Random random = new Random();
+
+  @Test
+  void testTransformRequest() {
+    byte[] bytes = new byte[102400]; // Mimic body of 100 Kibibyte
+    random.nextBytes(bytes);
+    Buffer dummyBody = Buffer.buffer(bytes);
+    ValidatableRequest request = mockValidatableRequest(dummyBody, APPLICATION_OCTET_STREAM.toString());
+    assertThat(transformer.transformRequest(null, request)).isEqualTo(dummyBody);
+  }
+
+  @Test
+  void testTransformRequestThrows() {
+    ValidatorException exception =
+      assertThrows(ValidatorException.class, () -> transformer.transformRequest(null,
+        mockValidatableRequest(Buffer.buffer("\"foobar"), APPLICATION_JSON.toString())));
+    String expectedMsg = "The request doesn't contain" +
+      " the required content-type header application/octet-stream.";
+    assertThat(exception.type()).isEqualTo(MISSING_REQUIRED_PARAMETER);
+    assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);
+  }
+
+  @Test
+  void testTransformResponse() {
+    byte[] bytes = new byte[102400]; // Mimic body of 100 Kibibyte
+    random.nextBytes(bytes);
+    Buffer dummyBody = Buffer.buffer(bytes);
+    ValidatableResponse response = ValidatableResponse.create(200, dummyBody,
+      APPLICATION_OCTET_STREAM.toString());
+    assertThat(transformer.transformResponse(null, response)).isEqualTo(dummyBody);
+  }
+
+  @Test
+  void testTransformResponseThrows() {
+    ValidatableResponse response = ValidatableResponse
+      .create(200, Buffer.buffer("\"foobar"), APPLICATION_JSON.toString());
+    ValidatorException exception =
+      assertThrows(ValidatorException.class, () -> transformer.transformResponse(null, response));
+    String expectedMsg = "The response doesn't contain" +
+      " the required content-type header application/octet-stream.";
+    assertThat(exception.type()).isEqualTo(MISSING_REQUIRED_PARAMETER);
+    assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);
+  }
+}


### PR DESCRIPTION
### Motivation:

OpenAPI 3.1 supports media type "application/octet-stream" in the request body.
See the migration guide: https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0

### Conformance:

I've signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md

### Current state of PR:
Pascal and I had trouble figuring out what the OpenAPI spec actually defines in regards of octet-stream/binary related endpoints. This confusion seems to be fixed with OpenAPI spec of version 3.1.1. For now, this PR is on hold until Pascal tells otherwise.