### PR TITLE
Fixing pom file by using the new codegen/docgen maven signatures.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,13 +67,13 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>vertx-codegen</artifactId>
+      <artifactId>vertx-codegen-processor</artifactId>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>vertx-docgen</artifactId>
+      <artifactId>vertx-docgen-processor</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -108,17 +108,17 @@
               <phase>compile</phase>
               <configuration>
                 <annotationProcessors>
-                  <annotationProcessor>io.vertx.codegen.CodeGenProcessor</annotationProcessor>
-                  <annotationProcessor>io.vertx.docgen.JavaDocGenProcessor</annotationProcessor>
+                  <annotationProcessor>io.vertx.codegen.processor.Processor</annotationProcessor>
+                  <annotationProcessor>io.vertx.docgen.processor.JavaDocGenProcessor</annotationProcessor>
                 </annotationProcessors>
                 <annotationProcessorPaths>
                   <annotationProcessorPath>
                     <groupId>io.vertx</groupId>
-                    <artifactId>vertx-codegen</artifactId>
+                    <artifactId>vertx-codegen-processor</artifactId>
                   </annotationProcessorPath>
                   <annotationProcessorPath>
                     <groupId>io.vertx</groupId>
-                    <artifactId>vertx-docgen</artifactId>
+                    <artifactId>vertx-docgen-processor</artifactId>
                   </annotationProcessorPath>
                 </annotationProcessorPaths>
               </configuration>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -8,7 +8,8 @@ module io.vertx.openapi {
   requires io.vertx.core.logging;
 
   requires static io.vertx.codegen.api;
-  requires static vertx.docgen;
+  requires static vertx.docgen.processor;
+  requires static io.vertx.docgen;
 
   exports io.vertx.openapi.contract;
   exports io.vertx.openapi.validation;

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -5,6 +5,7 @@ open module io.vertx.tests {
   requires io.vertx.jsonschema;
   requires io.vertx.openapi;
   requires io.vertx.testing.junit5;
+  requires io.netty.common;
   requires junit;
   requires org.junit.jupiter.api;
   requires org.junit.jupiter.params;


### PR DESCRIPTION
Motivation:
Vertx-openapi pom file is currently broken meaning a new version has been updated in the SNAPSHOT repo is some time. Updating to use the correct
