### PR TITLE
Updated additional contract validation error to include ref

### DIFF
--- a/src/main/java/io/vertx/openapi/contract/OpenAPIContract.java
+++ b/src/main/java/io/vertx/openapi/contract/OpenAPIContract.java
@@ -116,7 +116,16 @@ public interface OpenAPIContract {
         //  method and reused below.
         JsonObject file = additionalContractFiles.get(ref);
         Future<?> validationFuture = version.validateAdditionalContractFile(vertx, repository, file)
-          .compose(v -> vertx.executeBlocking(() -> repository.dereference(ref, JsonSchema.of(ref, file))));
+          .compose(v -> vertx.executeBlocking(() -> repository.dereference(ref, JsonSchema.of(ref, file))))
+          .transform(ar -> {
+            if (ar.failed()) {
+              return Future.failedFuture(
+                createInvalidContract("Failed to validate additional contract file: " + ref, ar.cause())
+              );
+            } else {
+              return (Future<?>) ar;
+            }
+          });
 
         validationFutures.add(validationFuture);
       }

--- a/src/test/java/io/vertx/tests/contract/OpenAPIContractTest.java
+++ b/src/test/java/io/vertx/tests/contract/OpenAPIContractTest.java
@@ -194,8 +194,10 @@ class OpenAPIContractTest {
         assertTrue(handler.failed());
         assertThat(handler.cause()).isInstanceOf(OpenAPIContractException.class);
         assertThat(handler.cause()).hasMessageThat()
-          .isEqualTo("The passed OpenAPI contract is invalid: Found issue in specification for reference:" +
-            " -1 is less than 0");
+          .isEqualTo("The passed OpenAPI contract is invalid: Failed to validate additional contract file: " +
+            "https://example.com/petstore");
+        assertThat(handler.cause().getCause()).hasMessageThat()
+          .isEqualTo("-1 is less than 0");
         testContext.completeNow();
       }));
   }


### PR DESCRIPTION
Motivation:

I started integrating using the newly updated `additionalContractFiles` feature and was running into an error in some unknown json schema. I could have made my own validation test that did the exact same validation/dereference process as OpenAPIContract, but it makes more sense to just specify which ref is causing the failure in the library.

I don't care what the error says. The only thing that matters to me is that the `ref` that caused an error shows up in the resulting exception.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
