### PR TITLE
Fix MediaType implementation of OpenApi 3.1

### DIFF
--- a/src/main/java/io/vertx/openapi/contract/impl/MediaTypeImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/MediaTypeImpl.java
@@ -33,7 +33,7 @@ public class MediaTypeImpl implements MediaType {
       throw createUnsupportedFeature("Media Type without a schema");
     }
 
-    if (mediaTypeModel.isEmpty()) {
+    if (mediaTypeModel.fieldNames().stream().allMatch(name -> name.startsWith("__"))) {
       // OpenAPI 3.1 allows defining MediaTypes without a schema.
       schema = null;
     } else {

--- a/src/main/java/io/vertx/openapi/contract/impl/MediaTypeImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/MediaTypeImpl.java
@@ -33,7 +33,12 @@ public class MediaTypeImpl implements MediaType {
       throw createUnsupportedFeature("Media Type without a schema");
     }
 
-    if (mediaTypeModel.fieldNames().stream().allMatch(name -> name.startsWith("__"))) {
+    boolean emptySchema = mediaTypeModel
+      .fieldNames().stream()
+      // Ignore all the internal json-schema annotations, they start and end with "__"
+      .allMatch(name -> name.startsWith("__") && name.endsWith("__"));
+
+    if (emptySchema) {
       // OpenAPI 3.1 allows defining MediaTypes without a schema.
       schema = null;
     } else {

--- a/src/test/java/io/vertx/tests/contract/impl/MediaTypeImplTest.java
+++ b/src/test/java/io/vertx/tests/contract/impl/MediaTypeImplTest.java
@@ -33,12 +33,35 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MediaTypeImplTest {
   private static final String DUMMY_IDENTIFIER = APPLICATION_JSON.toString();
+  private static final String DUMMY_REF = "__dummy_unknown_ref__";
+  private static final String ABS_URI = "__absolute_uri__";
+  private static final String ABS_RECURSIVE_REF = "__absolute_recursive_ref__";
+  private static final String ABS_REF = "__absolute_ref__";
+  private static final String DUMMY_REF_VALUE = "dummy-ref-value";
 
   private static Stream<Arguments> testGetters() {
     return Stream.of(
-      Arguments.of("MediaType model defined", new JsonObject().put("schema", stringSchema().toJson()), List.of("type"
-        , "$id")),
-      Arguments.of("No MediaType model defined", EMPTY_JSON_OBJECT, List.of())
+      Arguments.of("MediaType model defined, with no internal annotations", new JsonObject()
+        .put("schema", stringSchema().toJson()), List.of("type", "$id")),
+      Arguments.of("MediaType model defined, with an unknown internal annotation", new JsonObject()
+        .put(DUMMY_REF, DUMMY_REF_VALUE).put("schema", stringSchema().toJson()), List.of("type", "$id")),
+      Arguments.of("MediaType model defined, with multiple internal annotations", new JsonObject()
+        .put(ABS_URI, DUMMY_REF_VALUE)
+        .put(ABS_RECURSIVE_REF, DUMMY_REF_VALUE)
+        .put("schema", stringSchema().toJson()), List.of("type", "$id")),
+      Arguments.of("No MediaType model defined, with an unknown internal annotation", new JsonObject()
+        .put(DUMMY_REF, DUMMY_REF_VALUE), List.of()),
+      Arguments.of("No MediaType model defined, with absolute_uri internal annotation",
+        new JsonObject().put(ABS_URI, DUMMY_REF_VALUE), List.of()),
+      Arguments.of("No MediaType model defined, with absolute_recursive_ref internal annotation",
+        new JsonObject().put(ABS_RECURSIVE_REF, DUMMY_REF_VALUE), List.of()),
+      Arguments.of("No MediaType model defined, with absolute_ref internal annotation",
+        new JsonObject().put(ABS_REF, DUMMY_REF_VALUE), List.of()),
+      Arguments.of("No MediaType model defined, with multiple internal annotations", new JsonObject()
+        .put(ABS_URI, DUMMY_REF_VALUE)
+        .put(ABS_RECURSIVE_REF, DUMMY_REF_VALUE), List.of()),
+      Arguments.of("No MediaType model defined, with no internal annotations",
+        EMPTY_JSON_OBJECT, List.of())
     );
   }
 

--- a/src/test/java/io/vertx/tests/contract/impl/MediaTypeImplTest.java
+++ b/src/test/java/io/vertx/tests/contract/impl/MediaTypeImplTest.java
@@ -17,6 +17,7 @@ import io.vertx.openapi.contract.ContractErrorType;
 import io.vertx.openapi.contract.MediaType;
 import io.vertx.openapi.contract.OpenAPIContractException;
 import io.vertx.openapi.contract.impl.MediaTypeImpl;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -40,26 +41,31 @@ class MediaTypeImplTest {
   private static final String DUMMY_REF_VALUE = "dummy-ref-value";
 
   private static Stream<Arguments> testGetters() {
+    var partialSchemaJson = JsonObject.of("schema", stringSchema().toJson());
+
+    var partialUnknownAnnotation = JsonObject.of(DUMMY_REF, DUMMY_REF_VALUE);
+    var partialAbsoluteUri = JsonObject.of(ABS_URI, DUMMY_REF_VALUE);
+    var partialAbsoluteRecursiveRef = JsonObject.of(ABS_RECURSIVE_REF, DUMMY_REF_VALUE);
+    var partialAbsoluteRef = JsonObject.of(ABS_REF, DUMMY_REF_VALUE);
+    var partialMultipleAnnotations = partialAbsoluteUri.copy().mergeIn(partialUnknownAnnotation);
+
     return Stream.of(
-      Arguments.of("MediaType model defined, with no internal annotations", new JsonObject()
-        .put("schema", stringSchema().toJson()), List.of("type", "$id")),
-      Arguments.of("MediaType model defined, with an unknown internal annotation", new JsonObject()
-        .put(DUMMY_REF, DUMMY_REF_VALUE).put("schema", stringSchema().toJson()), List.of("type", "$id")),
-      Arguments.of("MediaType model defined, with multiple internal annotations", new JsonObject()
-        .put(ABS_URI, DUMMY_REF_VALUE)
-        .put(ABS_RECURSIVE_REF, DUMMY_REF_VALUE)
-        .put("schema", stringSchema().toJson()), List.of("type", "$id")),
-      Arguments.of("No MediaType model defined, with an unknown internal annotation", new JsonObject()
-        .put(DUMMY_REF, DUMMY_REF_VALUE), List.of()),
+      Arguments.of("MediaType model defined, with no internal annotations", partialSchemaJson,
+        List.of("type", "$id")),
+      Arguments.of("MediaType model defined, with an unknown internal annotation", partialSchemaJson
+        .copy().mergeIn(partialUnknownAnnotation), List.of("type", "$id")),
+      Arguments.of("MediaType model defined, with multiple internal annotations", partialSchemaJson
+        .copy().mergeIn(partialMultipleAnnotations), List.of("type", "$id")),
+      Arguments.of("No MediaType model defined, with an unknown internal annotation",
+        partialUnknownAnnotation, List.of()),
       Arguments.of("No MediaType model defined, with absolute_uri internal annotation",
-        new JsonObject().put(ABS_URI, DUMMY_REF_VALUE), List.of()),
+        partialAbsoluteUri, List.of()),
       Arguments.of("No MediaType model defined, with absolute_recursive_ref internal annotation",
-        new JsonObject().put(ABS_RECURSIVE_REF, DUMMY_REF_VALUE), List.of()),
+        partialAbsoluteRecursiveRef, List.of()),
       Arguments.of("No MediaType model defined, with absolute_ref internal annotation",
-        new JsonObject().put(ABS_REF, DUMMY_REF_VALUE), List.of()),
-      Arguments.of("No MediaType model defined, with multiple internal annotations", new JsonObject()
-        .put(ABS_URI, DUMMY_REF_VALUE)
-        .put(ABS_RECURSIVE_REF, DUMMY_REF_VALUE), List.of()),
+        partialAbsoluteRef, List.of()),
+      Arguments.of("No MediaType model defined, with multiple internal annotations",
+        partialMultipleAnnotations, List.of()),
       Arguments.of("No MediaType model defined, with no internal annotations",
         EMPTY_JSON_OBJECT, List.of())
     );


### PR DESCRIPTION
The internal `__absolute_uri__` flag is breaking the code that checks if the model is empty

Motivation:

OpenAPI 3.1 specifications do not work because vert.x populates the model with its own fields, then checks if the model is empty

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
