### PR TITLE
Add builder for OpenAPIContract.

### DIFF
--- a/src/main/java/io/vertx/openapi/contract/OpenAPIContract.java
+++ b/src/main/java/io/vertx/openapi/contract/OpenAPIContract.java
@@ -39,6 +39,15 @@ import static java.util.Collections.emptyMap;
 public interface OpenAPIContract {
 
   /**
+   * Instantiates a new builder for an openapi-contract.
+   * @param vertx The vert.x instance
+   * @return A new builder.
+   */
+  static OpenAPIContractBuilder builder(Vertx vertx) {
+    return new OpenAPIContractBuilder(vertx);
+  }
+
+  /**
    * Resolves / dereferences the passed contract and creates an {@link OpenAPIContract} instance.
    *
    * @param vertx                  The related Vert.x instance.
@@ -46,7 +55,7 @@ public interface OpenAPIContract {
    * @return A succeeded {@link Future} holding an {@link OpenAPIContract} instance, otherwise a failed {@link Future}.
    */
   static Future<OpenAPIContract> from(Vertx vertx, String unresolvedContractPath) {
-    return readYamlOrJson(vertx, unresolvedContractPath).compose(json -> from(vertx, json));
+    return builder(vertx).setContract(unresolvedContractPath).build();
   }
 
   /**
@@ -57,7 +66,11 @@ public interface OpenAPIContract {
    * @return A succeeded {@link Future} holding an {@link OpenAPIContract} instance, otherwise a failed {@link Future}.
    */
   static Future<OpenAPIContract> from(Vertx vertx, JsonObject unresolvedContract) {
-    return from(vertx, unresolvedContract, emptyMap());
+    if (unresolvedContract == null)
+      return Future.failedFuture(OpenAPIContractException.createInvalidContract("Spec must not be null"));
+    return builder(vertx)
+      .setContract(unresolvedContract)
+      .build();
   }
 
   /**
@@ -74,15 +87,10 @@ public interface OpenAPIContract {
   static Future<OpenAPIContract> from(Vertx vertx, String unresolvedContractPath,
                                       Map<String, String> additionalContractFiles) {
 
-    Map<String, Future<JsonObject>> jsonFilesFuture = new HashMap<>();
-    jsonFilesFuture.put(unresolvedContractPath, readYamlOrJson(vertx, unresolvedContractPath));
-    additionalContractFiles.forEach((key, value) -> jsonFilesFuture.put(key, readYamlOrJson(vertx, value)));
-
-    return Future.all(new ArrayList<>(jsonFilesFuture.values())).compose(compFut -> {
-      Map<String, JsonObject> resolvedFiles = new HashMap<>();
-      additionalContractFiles.keySet().forEach(key -> resolvedFiles.put(key, jsonFilesFuture.get(key).result()));
-      return from(vertx, jsonFilesFuture.get(unresolvedContractPath).result(), resolvedFiles);
-    });
+    return builder(vertx)
+      .setContract(unresolvedContractPath)
+      .setAdditionalContentFiles(additionalContractFiles)
+      .build();
   }
 
   /**
@@ -98,49 +106,12 @@ public interface OpenAPIContract {
    */
   static Future<OpenAPIContract> from(Vertx vertx, JsonObject unresolvedContract,
                                       Map<String, JsonObject> additionalContractFiles) {
-    if (unresolvedContract == null) {
-      return failedFuture(createInvalidContract("Spec must not be null"));
-    }
-
-    OpenAPIVersion version = OpenAPIVersion.fromContract(unresolvedContract);
-    String baseUri = "app://";
-
-    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
-    Promise<OpenAPIContract> promise = ctx.promise();
-
-    version.getRepository(vertx, baseUri)
-      .compose(repository -> {
-      List<Future<?>> validationFutures = new ArrayList<>(additionalContractFiles.size());
-      for (String ref : additionalContractFiles.keySet()) {
-        // Todo: As soon a more modern Java version is used the validate part could be extracted in a private static
-        //  method and reused below.
-        JsonObject file = additionalContractFiles.get(ref);
-        Future<?> validationFuture = version.validateAdditionalContractFile(vertx, repository, file)
-          .compose(v -> vertx.executeBlocking(() -> repository.dereference(ref, JsonSchema.of(ref, file))));
-
-        validationFutures.add(validationFuture);
-      }
-      return Future.all(validationFutures).map(repository);
-    }).compose(repository ->
-      version.validateContract(vertx, repository, unresolvedContract).compose(res -> {
-        try {
-          res.checkValidity();
-          return version.resolve(vertx, repository, unresolvedContract);
-        } catch (JsonSchemaValidationException | UnsupportedOperationException e) {
-          return failedFuture(createInvalidContract(null, e));
-        }
-      })
-      .map(resolvedSpec -> (OpenAPIContract) new OpenAPIContractImpl(resolvedSpec, version, repository))
-    ).recover(e -> {
-      //Convert any non-openapi exceptions into an OpenAPIContractException
-      if(e instanceof OpenAPIContractException) {
-        return failedFuture(e);
-      }
-
-      return failedFuture(createInvalidContract("Found issue in specification for reference: " + e.getMessage(), e));
-    }).onComplete(promise);
-
-    return promise.future();
+    if (unresolvedContract == null)
+      return Future.failedFuture(OpenAPIContractException.createInvalidContract("Spec must not be null"));
+    return builder(vertx)
+      .setContract(unresolvedContract)
+      .setAdditionalContent(additionalContractFiles)
+      .build();
   }
 
   /**

--- a/src/main/java/io/vertx/openapi/contract/OpenAPIContractBuilder.java
+++ b/src/main/java/io/vertx/openapi/contract/OpenAPIContractBuilder.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2025, Lukas Jelonek
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+package io.vertx.openapi.contract;
+
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.json.JsonObject;
+import io.vertx.json.schema.JsonSchema;
+import io.vertx.json.schema.JsonSchemaValidationException;
+import io.vertx.openapi.contract.impl.OpenAPIContractImpl;
+import io.vertx.openapi.impl.Utils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.openapi.contract.OpenAPIContractException.createInvalidContract;
+
+@GenIgnore
+public class OpenAPIContractBuilder {
+
+  public static class OpenAPIContractBuilderException extends RuntimeException {
+    public OpenAPIContractBuilderException(String message) {
+      super(message);
+    }
+  }
+
+  private final Vertx vertx;
+  private String contractFile;
+  private JsonObject contract;
+  private final Map<String, String> additionalContentFiles = new HashMap<>();
+  private final Map<String, JsonObject> additionalContent = new HashMap<>();
+
+  public OpenAPIContractBuilder(Vertx vertx) {
+    this.vertx = vertx;
+  }
+
+  /**
+   * Sets the path to the contract file. Either provide the path to the contract or the parsed contract,
+   * not both. Overrides the contract set by {@link #contract(JsonObject)}.
+   *
+   * @param contractPath The path to the contract file
+   * @return The builder, for a fluent interface
+   */
+  public OpenAPIContractBuilder setContract(String contractPath) {
+    this.contractFile = contractPath;
+    this.contract = null;
+    return this;
+  }
+
+  /**
+   * Sets the contract. Either provide the contract or the path to the contract,
+   * not both. Overrides the contract set by {@link #contract(String)}.
+   *
+   * @param contract The parsed contract
+   * @return The builder, for a fluent interface
+   */
+  public OpenAPIContractBuilder setContract(JsonObject contract) {
+    this.contract = contract;
+    this.contractFile = null;
+    return this;
+  }
+
+  /**
+   * Puts a contract that is referenced by the main contract. This method can be
+   * called multiple times to add multiple referenced contracts. Overrides a previously
+   * added contract, when the same key is used.
+   *
+   * @param key  The unique key for the contract.
+   * @param path The path to the contract file.
+   * @return The builder, for a fluent interface
+   */
+  public OpenAPIContractBuilder putAdditionalContentFile(String key, String path) {
+    additionalContentFiles.put(key, path);
+    additionalContent.remove(key);
+    return this;
+  }
+
+  /**
+   * Uses the contract files from the provided map to resolve referenced contracts.
+   * Replaces all previously put contracts by {@link #putAdditionalContentFile(String, String)}.
+   * If the same key is used also overrides the contracts set by {@link #putAdditionalContent(String, JsonObject)}
+   * and {@link #setAdditionalContent(Map)}.
+   *
+   * @param contractFiles A map that contains all additional contract files.
+   * @return The builder, for a fluent interface.
+   */
+  public OpenAPIContractBuilder setAdditionalContentFiles(Map<String, String> contractFiles) {
+    additionalContentFiles.clear();
+    for (var e : contractFiles.entrySet()) {
+      putAdditionalContentFile(e.getKey(), e.getValue());
+      additionalContent.remove(e.getKey());
+    }
+    return this;
+  }
+
+
+  /**
+   * Adds a contract that is referenced by the main contract. This method can be
+   * called multiple times to add multiple referenced contracts.
+   *
+   * @param key     The unique key for the contract.
+   * @param content The parsed contract.
+   * @return The builder, for a fluent interface
+   */
+  public OpenAPIContractBuilder putAdditionalContent(String key, JsonObject content) {
+    additionalContent.put(key, content);
+    additionalContentFiles.remove(key);
+    return this;
+  }
+
+  /**
+   * Uses the contracts from the provided map to resolve referenced contracts.
+   * Replaces all previously put contracts by {@link #putAdditionalContent(String, JsonObject)}.
+   * If the same key is used also replaces the contracts set by {@link #putAdditionalContentFile(String, String)}
+   * and {@link #setAdditionalContentFiles(Map)}.
+   *
+   * @param contracts A map that contains all additional contract files.
+   * @return The builder, for a fluent interface.
+   */
+  public OpenAPIContractBuilder setAdditionalContent(Map<String, JsonObject> contracts) {
+    additionalContent.clear();
+    for (var e : contracts.entrySet()) {
+      putAdditionalContent(e.getKey(), e.getValue());
+      additionalContentFiles.remove(e.getKey());
+    }
+    return this;
+  }
+
+  /**
+   * Builds the contract.
+   *
+   * @return The contract.
+   */
+  public Future<OpenAPIContract> build() {
+    if (contractFile == null && contract == null) {
+      return Future.failedFuture(new OpenAPIContractBuilderException("Neither a contract file or a contract is set. One of them must be set."));
+    }
+
+    Future<JsonObject> readContract = contractFile == null
+      ? Future.succeededFuture(contract)
+      : Utils.readYamlOrJson(vertx, contractFile);
+
+    var resolvedContracts = Future
+      .succeededFuture(additionalContent)
+      .compose(x -> readContractFiles()
+        .map(r -> {
+          var all = new HashMap<>(x);
+          all.putAll(r);
+          return all;
+        }));
+
+    return Future.all(readContract, resolvedContracts)
+      .compose(x -> {
+        JsonObject contract = x.resultAt(0);
+        Map<String, JsonObject> other = x.resultAt(1);
+        return from(contract, other);
+      });
+  }
+
+  private Future<OpenAPIContract> from(JsonObject unresolvedContract,
+                                       Map<String, JsonObject> additionalContractFiles) {
+    if (unresolvedContract == null) {
+      return failedFuture(createInvalidContract("Spec must not be null"));
+    }
+
+    OpenAPIVersion version = OpenAPIVersion.fromContract(unresolvedContract);
+    String baseUri = "app://";
+
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    Promise<OpenAPIContract> promise = ctx.promise();
+
+    version.getRepository(vertx, baseUri)
+      .compose(repository -> {
+        List<Future<?>> validationFutures = new ArrayList<>(additionalContractFiles.size());
+        for (String ref : additionalContractFiles.keySet()) {
+          // Todo: As soon a more modern Java version is used the validate part could be extracted in a private static
+          //  method and reused below.
+          JsonObject file = additionalContractFiles.get(ref);
+          Future<?> validationFuture = version.validateAdditionalContractFile(vertx, repository, file)
+            .compose(v -> vertx.executeBlocking(() -> repository.dereference(ref, JsonSchema.of(ref, file))));
+
+          validationFutures.add(validationFuture);
+        }
+        return Future.all(validationFutures).map(repository);
+      }).compose(repository ->
+        version.validateContract(vertx, repository, unresolvedContract).compose(res -> {
+            try {
+              res.checkValidity();
+              return version.resolve(vertx, repository, unresolvedContract);
+            } catch (JsonSchemaValidationException | UnsupportedOperationException e) {
+              return failedFuture(createInvalidContract(null, e));
+            }
+          })
+          .map(resolvedSpec -> new OpenAPIContractImpl(resolvedSpec, version, repository))
+      ).recover(e -> {
+        //Convert any non-openapi exceptions into an OpenAPIContractException
+        if (e instanceof OpenAPIContractException) {
+          return failedFuture(e);
+        }
+
+        return failedFuture(createInvalidContract("Found issue in specification for reference: " + e.getMessage(), e));
+      }).onComplete(promise);
+
+    return promise.future();
+  }
+
+  private Future<Map<String, JsonObject>> readContractFiles() {
+    if (additionalContentFiles.isEmpty()) return Future.succeededFuture(Map.of());
+
+    var read = new HashMap<String, JsonObject>();
+    return Future.all(additionalContentFiles.entrySet().stream()
+        .map(e -> Utils.readYamlOrJson(vertx, e.getValue())
+          .map(c -> read.put(e.getKey(), c)))
+        .collect(Collectors.toList()))
+      .map(ign -> read);
+  }
+
+}

--- a/src/test/java/io/vertx/tests/contract/OpenAPIContractBuilderTest.java
+++ b/src/test/java/io/vertx/tests/contract/OpenAPIContractBuilderTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2025, Lukas Jelonek
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+package io.vertx.tests.contract;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.openapi.contract.OpenAPIContract;
+import io.vertx.openapi.contract.OpenAPIContractBuilder;
+import io.vertx.openapi.contract.OpenAPIContractException;
+import io.vertx.openapi.impl.Utils;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Tests the OpenAPIContractBuilder. Only tests the different constellations a contract can be built from.
+ */
+@ExtendWith(VertxExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class OpenAPIContractBuilderTest {
+
+  @Test
+  void should_create_contract_when_valid_contract_file_is_provided(Vertx vertx, VertxTestContext ctx) {
+    OpenAPIContract.builder(vertx)
+      .setContract("v3.1/petstore.json")
+      .build()
+      .onComplete(ctx.succeedingThenComplete());
+  }
+
+  @Test
+  void should_create_contract_when_valid_contract_is_provided(Vertx vertx, VertxTestContext ctx) {
+    var contract = vertx.fileSystem().readFileBlocking("v3.1/petstore.json").toJsonObject();
+    OpenAPIContract.builder(vertx)
+      .setContract(contract)
+      .build()
+      .onComplete(ctx.succeedingThenComplete());
+  }
+
+  @Test
+  void should_create_contract_when_valid_contract_file_and_additional_file_is_provided(Vertx vertx, VertxTestContext ctx) {
+    OpenAPIContract.builder(vertx)
+      .setContract("io/vertx/tests/contract/from_with_path_and_additional_files/petstore.json")
+      .putAdditionalContentFile("https://example.com/petstore", "io/vertx/tests/contract/from_with_path_and_additional_files/components.json")
+      .build()
+      .onComplete(ctx.succeedingThenComplete());
+  }
+
+  @Test
+  void should_create_contract_when_valid_contract_and_additional_file_is_provided(Vertx vertx, VertxTestContext ctx) {
+    var contract = vertx.fileSystem().readFileBlocking("io/vertx/tests/contract/from_with_path_and_additional_files/petstore.json").toJsonObject();
+    OpenAPIContract.builder(vertx)
+      .setContract(contract)
+      .putAdditionalContentFile("https://example.com/petstore", "io/vertx/tests/contract/from_with_path_and_additional_files/components.json")
+      .build()
+      .onComplete(ctx.succeedingThenComplete());
+  }
+
+  @Test
+  void should_create_contract_when_valid_contract_file_and_additional_content_is_provided(Vertx vertx, VertxTestContext ctx) {
+    var components = vertx.fileSystem().readFileBlocking("io/vertx/tests/contract/from_with_path_and_additional_files/components.json").toJsonObject();
+    OpenAPIContract.builder(vertx)
+      .setContract("io/vertx/tests/contract/from_with_path_and_additional_files/petstore.json")
+      .putAdditionalContent("https://example.com/petstore", components)
+      .build()
+      .onComplete(ctx.succeedingThenComplete());
+  }
+
+  @Test
+  void should_fail_when_no_contract_or_contract_file_is_provided(Vertx vertx, VertxTestContext ctx) {
+    OpenAPIContract.builder(vertx)
+      .build()
+      .onComplete(ctx.failing(t -> ctx.verify(() -> {
+        assertThat(t).isInstanceOf(OpenAPIContractBuilder.OpenAPIContractBuilderException.class);
+        assertThat(t).hasMessageThat().isEqualTo("Neither a contract file or a contract is set. One of them must be set.");
+        ctx.completeNow();
+      })));
+  }
+
+  @Test
+  void should_fail_when_contract_is_invalid(Vertx vertx, VertxTestContext ctx) {
+    OpenAPIContract.builder(vertx)
+      .setContract(JsonObject.of())
+      .build()
+      .onComplete(ctx.failing(t -> ctx.verify(() -> {
+        assertThat(t).isInstanceOf(OpenAPIContractException.class);
+        ctx.completeNow();
+      })));
+  }
+
+  /**
+   * To test the override mechanisms for additional content we use the following setup: <br>
+   * We load a contract and add two additional contracts that exist in two versions, distinguishable
+   * by their title. Then we replace one of them with the other version and check if the correct
+   * version has been loaded.
+   */
+  @Nested
+  @ExtendWith(VertxExtension.class)
+  class TestSetupOfAdditionalContent {
+
+    private static final String REF1_ID = "http://example.com/ref1";
+    private static final String REF2_ID = "http://example.com/ref2";
+    private static final String REF1_1_FILE = "io/vertx/tests/builder/ref1.1.yaml";
+    private static final String REF1_2_FILE = "io/vertx/tests/builder/ref1.2.yaml";
+    private static final String REF2_1_FILE = "io/vertx/tests/builder/ref2.1.yaml";
+    private static final String REF2_2_FILE = "io/vertx/tests/builder/ref2.2.yaml";
+
+    private Vertx vertx;
+
+
+    @BeforeEach
+    void init(Vertx vertx) {
+      this.vertx = vertx;
+
+    }
+
+    private JsonObject content(String path) {
+      return Utils.readYamlOrJson(vertx, path).await();
+    }
+
+    @Test
+    void set_additional_content_should_override_existing_file(Vertx vertx) {
+      var c = OpenAPIContract.builder(vertx)
+        .setContract("io/vertx/tests/builder/contract.yaml")
+        .putAdditionalContentFile(REF1_ID, REF1_1_FILE)
+        .putAdditionalContentFile(REF2_ID, REF2_1_FILE)
+        .setAdditionalContent(Map.of(REF1_ID, content(REF1_2_FILE)))
+        .build()
+        .await();
+      should_have(c, "ref1.2", "ref2.1");
+    }
+
+    @Test
+    void put_additional_content_should_override_existing_file(Vertx vertx) {
+      var c = OpenAPIContract.builder(vertx)
+        .setContract("io/vertx/tests/builder/contract.yaml")
+        .putAdditionalContentFile(REF1_ID, REF1_1_FILE)
+        .putAdditionalContentFile(REF2_ID, REF2_1_FILE)
+        .putAdditionalContent(REF1_ID, content(REF1_2_FILE))
+        .build()
+        .await();
+      should_have(c, "ref1.2", "ref2.1");
+    }
+
+    @Test
+    void set_additional_content_file_should_override_existing_content(Vertx vertx) {
+      var c = OpenAPIContract.builder(vertx)
+        .setContract("io/vertx/tests/builder/contract.yaml")
+        .putAdditionalContent(REF1_ID, content(REF1_1_FILE))
+        .putAdditionalContent(REF2_ID, content(REF2_1_FILE))
+        .setAdditionalContentFiles(Map.of(REF2_ID, REF2_2_FILE))
+        .build()
+        .await();
+      should_have(c, "ref1.1", "ref2.2");
+    }
+
+    @Test
+    void put_additional_content_file_should_override_existing_content_file(Vertx vertx) {
+      var c = OpenAPIContract.builder(vertx)
+        .setContract("io/vertx/tests/builder/contract.yaml")
+        .putAdditionalContent(REF1_ID, content(REF1_1_FILE))
+        .putAdditionalContent(REF2_ID, content(REF2_1_FILE))
+        .putAdditionalContentFile(REF2_ID, REF2_2_FILE)
+        .build()
+        .await();
+      should_have(c, "ref1.1", "ref2.2");
+    }
+
+    private void should_have(OpenAPIContract contract, String requestDescription, String responseDescription) {
+      var c1 = contract.getSchemaRepository().find((REF1_ID));
+      var t1 = c1.<JsonObject>get("info").getString("title");
+      var c2 = contract.getSchemaRepository().find((REF2_ID));
+      var t2 = c2.<JsonObject>get("info").getString("title");
+      assertThat(t1).isEqualTo(requestDescription);
+      assertThat(t2).isEqualTo(responseDescription);
+    }
+
+    @Test
+    void set_additional_content_should_replace_existing_content(Vertx vertx) {
+      var c = OpenAPIContract.builder(vertx)
+        .setContract("io/vertx/tests/builder/contract.yaml")
+        .putAdditionalContent(REF1_ID, content(REF1_1_FILE))
+        .putAdditionalContent(REF2_ID, content(REF2_1_FILE))
+        .setAdditionalContent(Map.of(REF2_ID, content(REF2_2_FILE)))
+        .build()
+        .await();
+      assertThat(c.getSchemaRepository().find(REF1_ID)).isNull();
+    }
+
+    @Test
+    void set_additional_content_files_should_replace_existing_content_files(Vertx vertx) {
+      var c = OpenAPIContract.builder(vertx)
+        .setContract("io/vertx/tests/builder/contract.yaml")
+        .putAdditionalContentFile(REF1_ID, REF1_1_FILE)
+        .putAdditionalContentFile(REF2_ID, REF2_1_FILE)
+        .setAdditionalContentFiles(Map.of(REF2_ID, REF2_2_FILE))
+        .build()
+        .await();
+      assertThat(c.getSchemaRepository().find(REF1_ID)).isNull();
+    }
+  }
+
+}

--- a/src/test/resources/io/vertx/tests/builder/contract.yaml
+++ b/src/test/resources/io/vertx/tests/builder/contract.yaml
@@ -1,0 +1,5 @@
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: Builder-test
+paths: {}

--- a/src/test/resources/io/vertx/tests/builder/ref1.1.yaml
+++ b/src/test/resources/io/vertx/tests/builder/ref1.1.yaml
@@ -1,0 +1,5 @@
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: ref1.1
+components: {}

--- a/src/test/resources/io/vertx/tests/builder/ref1.2.yaml
+++ b/src/test/resources/io/vertx/tests/builder/ref1.2.yaml
@@ -1,0 +1,6 @@
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: ref1.2
+components: {}
+

--- a/src/test/resources/io/vertx/tests/builder/ref2.1.yaml
+++ b/src/test/resources/io/vertx/tests/builder/ref2.1.yaml
@@ -1,0 +1,5 @@
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: ref2.1
+components: {}

--- a/src/test/resources/io/vertx/tests/builder/ref2.2.yaml
+++ b/src/test/resources/io/vertx/tests/builder/ref2.2.yaml
@@ -1,0 +1,5 @@
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: ref2.2
+components: {}


### PR DESCRIPTION
Will allow to add new fields to the contract setup without requiring to change or to add new factory methods.

Motivation:

Split the pull request #101 into two simpler request: one for the builder part, one for the additional media types. This pull request covers the first part.

Conformance:

You should have signed the Eclipse Contributor Agreement: Done
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines: May require some reformatting.
