### PR TITLE
Allow Support of Custom Media Types

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -151,3 +151,51 @@ The validation can fail for formal reasons, such as the wrong format for a param
 However, validation can of course also fail because the content does not match the defined schema.
 In this case a {@link io.vertx.openapi.validation.SchemaValidationException} is thrown.
 It is a subclass of _ValidatorException_ and provides access to the related {@link io.vertx.json.schema.OutputUnit} to allow further analysis of the error.
+
+=== Support Custom Media Types
+
+Custom media types that are currently not supported out of the box can be used by implementing a custom mapping of those
+media type to JSON. This is done by creating a custom instance of a {@link io.vertx.openapi.validation.analyser.ContentAnalyserFactory}
+and a corresponding {@link io.vertx.openapi.validation.analyser.ContentAnalyser} implementation.
+
+In order to use those custom media types, they can be specified through
+{@link io.vertx.openapi.contract.OpenAPIContractBuilder#registerSupportedMediaType}:
+
+[source,$lang]
+----
+{@link examples.ContractExamples#customMediaTypes}
+----
+
+==== Unchecked (Opaque) Media Types
+
+It is also possible to register a media type that will be handled as an opaque string instead of transforming them into
+JSON by calling{@link io.vertx.openapi.contract.OpenAPIContractBuilder#registerUncheckedMediaType}:
+
+[source,$lang]
+----
+{@link examples.ContractExamples#uncheckedMediaTypes}
+----
+
+NOTE: If you specify a schema for any unchecked media type in your OpenAPI contract, the request or response validator
+built from that contract might still attempt schema validation, which will likely fail. To disable schema validation,
+you can set the schema to be an unrestricted binary string (see below) or by omitting the schema altogether (only
+allowed in OpenAPI 3.1)
+
+[source,yaml]
+----
+paths:
+  /sse:
+    get:
+      operationId: uncheckedMediaType
+      responses:
+        default:
+          description: An SSE stream
+          content:
+            # OpenAPI 3.0 and 3.1: Unrestricted binary schema
+            text/event-stream:
+              schema:
+                type: string
+                format: binary
+            # Only OpenAPI 3.1:
+            # text/event-stream: {}
+----

--- a/src/main/java/examples/ContractExamples.java
+++ b/src/main/java/examples/ContractExamples.java
@@ -18,6 +18,7 @@ import io.vertx.openapi.contract.OpenAPIContract;
 import io.vertx.openapi.contract.Operation;
 import io.vertx.openapi.contract.Parameter;
 import io.vertx.openapi.contract.Path;
+import io.vertx.openapi.validation.analyser.ContentAnalyserFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -58,7 +59,30 @@ public class ContractExamples {
     }
   }
 
+  public void customMediaTypes(Vertx vertx) {
+    ContentAnalyserFactory yamlFactory = getYamlFactory();
+
+    OpenAPIContract.builder(vertx)
+        .registerSupportedMediaType(
+            "application/yaml",
+              yamlFactory,
+              // Can specify more aliases for the same media type
+              "application/yml");
+  }
+
+  public void uncheckedMediaTypes(Vertx vertx) {
+    OpenAPIContract.builder(vertx)
+        .registerUncheckedMediaType(
+            "text/event-stream",
+              // Can specify more aliases for the same media type
+              "text/event-stream; charset=utf-8");
+  }
+
   private OpenAPIContract getContract() {
+    return null;
+  }
+
+  private ContentAnalyserFactory getYamlFactory() {
     return null;
   }
 }

--- a/src/main/java/io/vertx/openapi/contract/MediaType.java
+++ b/src/main/java/io/vertx/openapi/contract/MediaType.java
@@ -15,7 +15,9 @@ package io.vertx.openapi.contract;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.json.schema.JsonSchema;
 import io.vertx.openapi.contract.impl.VendorSpecificJson;
+import io.vertx.openapi.validation.analyser.ContentAnalyserFactory;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This interface represents the most important attributes of an OpenAPI Operation.
@@ -37,8 +39,9 @@ public interface MediaType extends OpenAPIObject {
   List<String> SUPPORTED_MEDIA_TYPES = List.of(APPLICATION_JSON, APPLICATION_JSON_UTF8, MULTIPART_FORM_DATA,
       APPLICATION_HAL_JSON, APPLICATION_OCTET_STREAM, TEXT_PLAIN, TEXT_PLAIN_UTF8);
 
-  static boolean isMediaTypeSupported(String type) {
-    return SUPPORTED_MEDIA_TYPES.contains(type.toLowerCase()) || isVendorSpecificJson(type);
+  static boolean isMediaTypeSupported(String type, Map<String, ContentAnalyserFactory> additionalMediaTypes) {
+    return (additionalMediaTypes != null && additionalMediaTypes.containsKey(type.toLowerCase())) ||
+        SUPPORTED_MEDIA_TYPES.contains(type.toLowerCase()) || isVendorSpecificJson(type);
   }
 
   static boolean isVendorSpecificJson(String type) {

--- a/src/main/java/io/vertx/openapi/contract/OpenAPIContractBuilder.java
+++ b/src/main/java/io/vertx/openapi/contract/OpenAPIContractBuilder.java
@@ -162,13 +162,13 @@ public class OpenAPIContractBuilder {
    * mapping to JSON. This is done by implementing a ContentAnalyser and a ContentAnalyserFactory. See their Javadoc
    * for details.
    *
-   * @param contentAnalyserFactory the custom JSON mapping for the registered media type
    * @param mediaType the media type to register
+   * @param contentAnalyserFactory the custom JSON mapping for the registered media type
    * @param aliases alternative names for the same media type (e.g. including a charset parameter)
    * @return a reference to this for chaining
    */
   public OpenAPIContractBuilder registerSupportedMediaType(
-    ContentAnalyserFactory contentAnalyserFactory, String mediaType, String... aliases
+    String mediaType, ContentAnalyserFactory contentAnalyserFactory, String... aliases
   ) {
     additionalMediaTypes.put(mediaType, contentAnalyserFactory);
     Arrays.stream(aliases).forEach(alias -> additionalMediaTypes.put(alias, contentAnalyserFactory));
@@ -188,7 +188,7 @@ public class OpenAPIContractBuilder {
    * @return a reference to this for chaining
    */
   public OpenAPIContractBuilder registerUncheckedMediaType(String mediaType, String... aliases) {
-    return registerSupportedMediaType(ContentAnalyserFactory.NO_OP, mediaType, aliases);
+    return registerSupportedMediaType(mediaType, ContentAnalyserFactory.NO_OP, aliases);
   }
 
   /**

--- a/src/main/java/io/vertx/openapi/contract/impl/MediaTypeImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/MediaTypeImpl.java
@@ -17,6 +17,8 @@ import static io.vertx.openapi.contract.OpenAPIContractException.createUnsupport
 import io.vertx.core.json.JsonObject;
 import io.vertx.json.schema.JsonSchema;
 import io.vertx.openapi.contract.MediaType;
+import io.vertx.openapi.validation.analyser.ContentAnalyserFactory;
+import java.util.Map;
 
 public class MediaTypeImpl implements MediaType {
   private static final String KEY_SCHEMA = "schema";
@@ -25,7 +27,9 @@ public class MediaTypeImpl implements MediaType {
 
   private final JsonSchema schema;
 
-  public MediaTypeImpl(String identifier, JsonObject mediaTypeModel) {
+  private final ContentAnalyserFactory contentAnalyserFactory;
+
+  public MediaTypeImpl(String identifier, JsonObject mediaTypeModel, Map<String, ? extends ContentAnalyserFactory> additionalMediaTypes) {
     this.identifier = identifier;
     this.mediaTypeModel = mediaTypeModel;
 
@@ -47,7 +51,12 @@ public class MediaTypeImpl implements MediaType {
         throw createUnsupportedFeature("Media Type without a schema");
       }
       schema = JsonSchema.of(schemaJson);
+    }
 
+    if (additionalMediaTypes != null) {
+      contentAnalyserFactory = additionalMediaTypes.get(identifier.toLowerCase());
+    } else {
+      contentAnalyserFactory = null;
     }
   }
 
@@ -64,5 +73,9 @@ public class MediaTypeImpl implements MediaType {
   @Override
   public JsonObject getOpenAPIModel() {
     return mediaTypeModel;
+  }
+
+  public ContentAnalyserFactory getContentAnalyserFactory() {
+    return contentAnalyserFactory;
   }
 }

--- a/src/main/java/io/vertx/openapi/contract/impl/PathImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/PathImpl.java
@@ -31,6 +31,7 @@ import io.vertx.openapi.contract.Operation;
 import io.vertx.openapi.contract.Parameter;
 import io.vertx.openapi.contract.Path;
 import io.vertx.openapi.contract.SecurityRequirement;
+import io.vertx.openapi.validation.analyser.ContentAnalyserFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -62,7 +63,7 @@ public class PathImpl implements Path {
   private final JsonObject pathModel;
   private final String absolutePath;
 
-  public PathImpl(String basePath, String name, JsonObject pathModel, List<SecurityRequirement> globalSecReq) {
+  public PathImpl(String basePath, String name, JsonObject pathModel, List<SecurityRequirement> globalSecReq, Map<String, ContentAnalyserFactory> additionalMediaTypes) {
     this.absolutePath = (basePath.endsWith("/") ? basePath.substring(0, basePath.length() - 1) : basePath) + name;
     this.pathModel = pathModel;
     if (name.contains("*")) {
@@ -82,7 +83,7 @@ public class PathImpl implements Path {
     List<Operation> ops = new ArrayList<>();
     SUPPORTED_METHODS.forEach((methodName, method) -> Optional.ofNullable(pathModel.getJsonObject(methodName))
         .map(operationModel -> new OperationImpl(absolutePath, name, method, operationModel, parameters,
-            getExtensions(), globalSecReq))
+            getExtensions(), globalSecReq, additionalMediaTypes))
         .ifPresent(ops::add));
     this.operations = unmodifiableList(ops);
   }

--- a/src/main/java/io/vertx/openapi/contract/impl/ResponseImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/ResponseImpl.java
@@ -29,6 +29,7 @@ import io.vertx.json.schema.JsonSchema;
 import io.vertx.openapi.contract.MediaType;
 import io.vertx.openapi.contract.Parameter;
 import io.vertx.openapi.contract.Response;
+import io.vertx.openapi.validation.analyser.ContentAnalyserFactory;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -45,7 +46,7 @@ public class ResponseImpl implements Response {
 
   private final JsonObject responseModel;
 
-  public ResponseImpl(JsonObject responseModel, String operationId) {
+  public ResponseImpl(JsonObject responseModel, String operationId, Map<String, ContentAnalyserFactory> additionalMediaTypes) {
     this.responseModel = responseModel;
 
     JsonObject headersObject = responseModel.getJsonObject(KEY_HEADERS, EMPTY_JSON_OBJECT);
@@ -66,9 +67,9 @@ public class ResponseImpl implements Response {
             .fieldNames()
             .stream()
             .filter(JsonSchema.EXCLUDE_ANNOTATIONS)
-            .collect(toMap(identity(), key -> new MediaTypeImpl(key, contentObject.getJsonObject(key)))));
+            .collect(toMap(identity(), key -> new MediaTypeImpl(key, contentObject.getJsonObject(key), additionalMediaTypes))));
 
-    if (content.keySet().stream().anyMatch(type -> !isMediaTypeSupported(type))) {
+    if (content.keySet().stream().anyMatch(type -> !isMediaTypeSupported(type, additionalMediaTypes))) {
       String msgTemplate = "Operation %s defines a response with an unsupported media type. Supported: %s";
       throw createUnsupportedFeature(String.format(msgTemplate, operationId, join(", ", SUPPORTED_MEDIA_TYPES)));
     }

--- a/src/main/java/io/vertx/openapi/validation/analyser/ContentAnalyserFactory.java
+++ b/src/main/java/io/vertx/openapi/validation/analyser/ContentAnalyserFactory.java
@@ -1,0 +1,38 @@
+package io.vertx.openapi.validation.analyser;
+
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.openapi.validation.ValidationContext;
+
+/**
+ * A factory to create content analysers for custom media types. Two common instances are provided:
+ *
+ * <li>ContentAnalyserFactory.NO_OP: A content analyser factory that treats input as an opaque octet string</li>
+ * <li>ContentAnalyserFactory.JSON: A content analyser factory that treats input as JSON and decodes it for validation</li>
+ */
+@VertxGen
+public interface ContentAnalyserFactory {
+  /**
+   * A factory creating no-op content analysers that treat content as an opaque octet string. It can be used for content
+   * types that do not require or support schema validation.
+   */
+  ContentAnalyserFactory NO_OP = ContentAnalyser.NoOpAnalyser::new;
+
+  /**
+   * A factory creating content analysers that treat the content as JSON and decode it for schema validation.
+   */
+  ContentAnalyserFactory JSON = ApplicationJsonAnalyser::new;
+
+  /**
+   * Returns a content analyser for the given content type, working over the given content in the context of a response
+   * or request, as indicated by the context parameter.
+   *
+   * @param contentType the content type to return an analyzer for
+   * @param content the raw request or response body content
+   * @param context the validation context (REQUEST or RESPONSE)
+   * @return a content analyser for the given content type and content
+   */
+  @GenIgnore
+  ContentAnalyser getContentAnalyser(String contentType, Buffer content, ValidationContext context);
+}

--- a/src/test/java/io/vertx/tests/contract/OpenAPIContractBuilderTest.java
+++ b/src/test/java/io/vertx/tests/contract/OpenAPIContractBuilderTest.java
@@ -313,8 +313,9 @@ public class OpenAPIContractBuilderTest {
       OpenAPIContract.builder(vertx)
           .setContract(CONTRACT)
           .registerSupportedMediaType(
+              "application/yml",
               new RequestValidatorImplTest.YamlContentAnalyzerFactory(),
-              "application/yml", "application/yaml"
+              "application/yaml"
           )
           .registerUncheckedMediaType("text/event-stream")
           .build()

--- a/src/test/java/io/vertx/tests/validation/impl/BaseValidatorTest.java
+++ b/src/test/java/io/vertx/tests/validation/impl/BaseValidatorTest.java
@@ -15,6 +15,7 @@ package io.vertx.tests.validation.impl;
 import static com.google.common.truth.Truth.assertThat;
 import static io.vertx.openapi.impl.Utils.EMPTY_JSON_OBJECT;
 import static io.vertx.tests.ResourceHelper.TEST_RESOURCE_PATH;
+import static java.util.Collections.emptyMap;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -83,14 +84,14 @@ class BaseValidatorTest {
     JsonObject binaryStringSchema = stringSchema.copy().put("format", "binary");
     Function<JsonObject, JsonObject> buildMediaModel = schema -> new JsonObject().put("schema", schema);
 
-    MediaType noMediaModel = new MediaTypeImpl("", EMPTY_JSON_OBJECT);
-    MediaType typeNumber = new MediaTypeImpl("", buildMediaModel.apply(new JsonObject().put("type", "number")));
-    MediaType typeStringNoFormat = new MediaTypeImpl("", buildMediaModel.apply(stringSchema));
-    MediaType typeStringFormatBinary = new MediaTypeImpl("", buildMediaModel.apply(binaryStringSchema));
+    MediaType noMediaModel = new MediaTypeImpl("", EMPTY_JSON_OBJECT, emptyMap());
+    MediaType typeNumber = new MediaTypeImpl("", buildMediaModel.apply(new JsonObject().put("type", "number")), emptyMap());
+    MediaType typeStringNoFormat = new MediaTypeImpl("", buildMediaModel.apply(stringSchema), emptyMap());
+    MediaType typeStringFormatBinary = new MediaTypeImpl("", buildMediaModel.apply(binaryStringSchema), emptyMap());
     MediaType typeStringFormatTime = new MediaTypeImpl("", buildMediaModel.apply(stringSchema.copy().put("format",
-        "time")));
+        "time")), emptyMap());
     MediaType typeStringFormatBinaryMinLength = new MediaTypeImpl("",
-        buildMediaModel.apply(binaryStringSchema.copy().put("minLength", 1)));
+        buildMediaModel.apply(binaryStringSchema.copy().put("minLength", 1)), emptyMap());
 
     return Stream.of(
         Arguments.of("No media model is defined", noMediaModel, false),

--- a/src/test/resources/io/vertx/tests/contract/impl/contract_valid.json
+++ b/src/test/resources/io/vertx/tests/contract/impl/contract_valid.json
@@ -447,5 +447,392 @@
         }
       }
     }
+  },
+  "0002_Test_Custom_Media_Types": {
+    "contractModel": {
+      "openapi": "3.1.0",
+      "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore",
+        "license": {
+          "identifier": "MIT",
+          "name": "MIT License"
+        }
+      },
+      "servers": [
+        {
+          "url": "https://petstore.swagger.io/v1"
+        }
+      ],
+      "security": [
+        {
+          "BasicAuth": []
+        }
+      ],
+      "paths": {
+        "/pets": {
+          "get": {
+            "summary": "List all pets",
+            "operationId": "listPets",
+            "tags": [
+              "pets"
+            ],
+            "parameters": [
+              {
+                "name": "limit",
+                "in": "query",
+                "description": "How many items to return at one time (max 100)",
+                "required": false,
+                "schema": {
+                  "type": "integer",
+                  "maximum": 100,
+                  "format": "int32"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "A paged array of pets",
+                "headers": {
+                  "x-next": {
+                    "description": "A link to the next page of responses",
+                    "schema": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "array",
+                      "maxItems": 100,
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "tag": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "application/xml": {
+                    "schema": {
+                      "type": "array",
+                      "maxItems": 100,
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "tag": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "description": "unexpected error",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "post": {
+            "summary": "Create a pet",
+            "operationId": "createPets",
+            "tags": [
+              "pets"
+            ],
+            "requestBody": {
+              "description": "Create a new pet in the store",
+              "required": true,
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "required": [
+                      "id",
+                      "name"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "application/yml": {
+                  "schema": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "201": {
+                "description": "Null response"
+              },
+              "400": {
+                "description": "Bad Request",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "description": "unexpected error",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/pets/{petId}": {
+          "get": {
+            "summary": "Info for a specific pet",
+            "operationId": "showPetById",
+            "tags": [
+              "pets"
+            ],
+            "parameters": [
+              {
+                "name": "petId",
+                "in": "path",
+                "required": true,
+                "description": "The id of the pet to retrieve",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Expected response to a valid request",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "object",
+                      "required": [
+                        "id",
+                        "name"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "format": "int64"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "tag": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "400": {
+                "description": "Bad Request",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "description": "unexpected error",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "components": {
+        "schemas": {
+          "Pet": {
+            "type": "object",
+            "required": [
+              "id",
+              "name"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tag": {
+                "type": "string"
+              }
+            }
+          },
+          "Pets": {
+            "type": "array",
+            "maxItems": 100,
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "name"
+              ],
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "Error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "securitySchemes": {
+          "BasicAuth": {
+            "scheme": "basic",
+            "type": "http"
+          }
+        }
+      }
+    }
   }
 }

--- a/src/test/resources/io/vertx/tests/contract/impl/operation_valid.json
+++ b/src/test/resources/io/vertx/tests/contract/impl/operation_valid.json
@@ -215,5 +215,49 @@
         }
       }
     }
+  },
+  "0006_Test_RequestBody_Custom_Media_type": {
+    "path": "/pets",
+    "method": "post",
+    "operationModel": {
+      "operationId": "createPet",
+      "tags": [
+        "pets",
+        "foo"
+      ],
+      "requestBody": {
+        "description": "Create a new pet in the store",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          },
+          "text/event-stream": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "responses": {
+        "default": {
+          "description": "unexpected error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            },
+            "text/event-stream": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/src/test/resources/io/vertx/tests/contract/impl/path_valid.json
+++ b/src/test/resources/io/vertx/tests/contract/impl/path_valid.json
@@ -41,5 +41,92 @@
         }
       ]
     }
+  },
+  "0001_Test_Custom_Media_Type": {
+    "name": "/pets/{petId}",
+    "pathModel": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Info for a specific pet",
+        "operationId": "updatePet",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/xml": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "petId",
+          "in": "query",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    }
   }
 }

--- a/src/test/resources/io/vertx/tests/contract/impl/requestBody_valid.json
+++ b/src/test/resources/io/vertx/tests/contract/impl/requestBody_valid.json
@@ -27,5 +27,19 @@
         }
       }
     }
+  },
+  "0003_Test_Custom_MediaType": {
+    "content": {
+      "application/json": {
+        "schema": {
+          "type": "string"
+        }
+      },
+      "text/event-stream": {
+        "schema": {
+          "type": "string"
+        }
+      }
+    }
   }
 }

--- a/src/test/resources/io/vertx/tests/contract/impl/response_valid.json
+++ b/src/test/resources/io/vertx/tests/contract/impl/response_valid.json
@@ -46,5 +46,19 @@
     }
   },
   "0003_Test_Getters_No_Headers_No_Content": {
+  },
+  "0004_Test_Custom_MediaType": {
+    "content": {
+      "application/json": {
+        "schema": {
+          "type": "string"
+        }
+      },
+      "text/event-stream": {
+        "schema": {
+          "type": "string"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Motivation:

In the current implementation, it is impossible to use OpenAPI schemas that have media types which are unsupported by the library. In our concrete use case, we have multiple SSE endpoints (media type `text/event-stream`) that are not supposed to be validated, but `vertx-openapi` still refuses to parse the contract, as the media type is none of the predefined supported media types.

In this PR, I extend the `OpenAPIContractBuilder` to allow users to specify additional supported media types, as long as they provide a mapping of those media types to JSON (for schema validation) or specify that the media type should be treated as an opaque string and remain unchecked.

The main user-facing change are two new methods in `OpenAPIContractBuilder` and a new interface for constructing custom `ContentAnalyser`s:

* `OpenAPIContractBuilder.registerSupportedMediaType` registers a media type together with a `ContentAnalyserFactory` that provides a JSON mapping of that media type
* `OpenAPIContractBuilder.registerUncheckedMediaType` registers a media type as an opaque unchecked string
* `ContentAnalyserFactory` creates content analysers. Users can create their own implementations of `ContentAnalyser` and a matching factory in order to support custom media types.

Internally, a map of additional supported media types is passed down through the OpenAPIContractImpl hierarchy at construction time. The `MediaTypeImpl` class stores a reference to the matching custom `ContentAnalyserFactory`, if any.

All changes are tested and documented.
