### PR TITLE
Feature/form urlencoded support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ hs_err_pid*
 vertx-json-validator.iml
 .idea/
 *.iml
+.vscode/settings.json

--- a/src/main/java/io/vertx/openapi/mediatype/ContentAnalyserFactory.java
+++ b/src/main/java/io/vertx/openapi/mediatype/ContentAnalyserFactory.java
@@ -17,6 +17,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.openapi.mediatype.impl.ApplicationJsonAnalyser;
 import io.vertx.openapi.mediatype.impl.MultipartFormAnalyser;
 import io.vertx.openapi.mediatype.impl.NoOpAnalyser;
+import io.vertx.openapi.mediatype.impl.XWwwFormUrlencodedAnalyser;
 import io.vertx.openapi.validation.ValidationContext;
 
 @VertxGen
@@ -42,5 +43,9 @@ public interface ContentAnalyserFactory {
 
   static ContentAnalyserFactory multipart() {
     return MultipartFormAnalyser::new;
+  }
+
+  static ContentAnalyserFactory xWwwFormUrlencoded() {
+    return XWwwFormUrlencodedAnalyser::new;
   }
 }

--- a/src/main/java/io/vertx/openapi/mediatype/MediaTypeRegistration.java
+++ b/src/main/java/io/vertx/openapi/mediatype/MediaTypeRegistration.java
@@ -12,13 +12,12 @@
 
 package io.vertx.openapi.mediatype;
 
-import java.util.List;
-import java.util.regex.Pattern;
-
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.openapi.mediatype.impl.DefaultMediaTypeRegistration;
 import io.vertx.openapi.validation.ValidationContext;
+import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * A MediaTypeRegistration is used to register mediatypes to the openapi mediatype registry. It consists of a predicate
@@ -47,7 +46,7 @@ public interface MediaTypeRegistration {
   MediaTypeRegistration APPLICATION_OCTET_STREAM = new DefaultMediaTypeRegistration(
       MediaTypePredicate.ofExactTypes(DefaultMediaTypeRegistration.APPLICATION_OCTET_STREAM),
       ContentAnalyserFactory.noop());
-      
+
   MediaTypeRegistration APPLICATION_X_WWW_FORM_URL_ENCODED = new DefaultMediaTypeRegistration(
       MediaTypePredicate.ofExactTypes(DefaultMediaTypeRegistration.APPLICATION_X_WWW_FORM_URL_ENCODED),
       ContentAnalyserFactory.xWwwFormUrlencoded());

--- a/src/main/java/io/vertx/openapi/mediatype/MediaTypeRegistration.java
+++ b/src/main/java/io/vertx/openapi/mediatype/MediaTypeRegistration.java
@@ -12,12 +12,13 @@
 
 package io.vertx.openapi.mediatype;
 
+import java.util.List;
+import java.util.regex.Pattern;
+
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.openapi.mediatype.impl.DefaultMediaTypeRegistration;
 import io.vertx.openapi.validation.ValidationContext;
-import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * A MediaTypeRegistration is used to register mediatypes to the openapi mediatype registry. It consists of a predicate
@@ -46,6 +47,10 @@ public interface MediaTypeRegistration {
   MediaTypeRegistration APPLICATION_OCTET_STREAM = new DefaultMediaTypeRegistration(
       MediaTypePredicate.ofExactTypes(DefaultMediaTypeRegistration.APPLICATION_OCTET_STREAM),
       ContentAnalyserFactory.noop());
+      
+  MediaTypeRegistration APPLICATION_X_WWW_FORM_URL_ENCODED = new DefaultMediaTypeRegistration(
+      MediaTypePredicate.ofExactTypes(DefaultMediaTypeRegistration.APPLICATION_X_WWW_FORM_URL_ENCODED),
+      ContentAnalyserFactory.xWwwFormUrlencoded());
 
   MediaTypeRegistration VENDOR_SPECIFIC_JSON = new DefaultMediaTypeRegistration(
       MediaTypePredicate.ofRegexp(Pattern.compile("^[^/]+/vnd\\.[\\w.-]+\\+json$").pattern()),

--- a/src/main/java/io/vertx/openapi/mediatype/MediaTypeRegistry.java
+++ b/src/main/java/io/vertx/openapi/mediatype/MediaTypeRegistry.java
@@ -12,10 +12,9 @@
 
 package io.vertx.openapi.mediatype;
 
-import java.util.List;
-
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.openapi.mediatype.impl.DefaultMediaTypeRegistry;
+import java.util.List;
 
 /**
  * The MediaTypeRegistry contains all supported MediaTypes and Validators for

--- a/src/main/java/io/vertx/openapi/mediatype/MediaTypeRegistry.java
+++ b/src/main/java/io/vertx/openapi/mediatype/MediaTypeRegistry.java
@@ -12,18 +12,21 @@
 
 package io.vertx.openapi.mediatype;
 
-import io.vertx.codegen.annotations.VertxGen;
-import io.vertx.openapi.mediatype.impl.DefaultMediaTypeRegistry;
 import java.util.List;
 
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.openapi.mediatype.impl.DefaultMediaTypeRegistry;
+
 /**
- * The MediaTypeRegistry contains all supported MediaTypes and Validators for the mediatypes. New MediaTypes can be registered
+ * The MediaTypeRegistry contains all supported MediaTypes and Validators for
+ * the mediatypes. New MediaTypes can be registered
  * by providing new MediaTypeRegistrations.
  */
 @VertxGen
 public interface MediaTypeRegistry {
   /**
-   * Creates a default registry with application/json, application/multipart and text/plain mediatypes registered.
+   * Creates a default registry with application/json, application/multipart and
+   * text/plain mediatypes registered.
    *
    * @return A registry with default options.
    */
@@ -32,6 +35,7 @@ public interface MediaTypeRegistry {
         .register(MediaTypeRegistration.APPLICATION_JSON)
         .register(MediaTypeRegistration.MULTIPART_FORM_DATA)
         .register(MediaTypeRegistration.APPLICATION_OCTET_STREAM)
+        .register(MediaTypeRegistration.APPLICATION_X_WWW_FORM_URL_ENCODED)
         .register(MediaTypeRegistration.TEXT_PLAIN)
         .register(MediaTypeRegistration.VENDOR_SPECIFIC_JSON);
   }

--- a/src/main/java/io/vertx/openapi/mediatype/impl/DefaultMediaTypeRegistration.java
+++ b/src/main/java/io/vertx/openapi/mediatype/impl/DefaultMediaTypeRegistration.java
@@ -12,6 +12,8 @@
 
 package io.vertx.openapi.mediatype.impl;
 
+import java.util.List;
+
 import io.vertx.core.buffer.Buffer;
 import io.vertx.openapi.mediatype.ContentAnalyser;
 import io.vertx.openapi.mediatype.ContentAnalyserFactory;
@@ -19,7 +21,6 @@ import io.vertx.openapi.mediatype.MediaTypeInfo;
 import io.vertx.openapi.mediatype.MediaTypePredicate;
 import io.vertx.openapi.mediatype.MediaTypeRegistration;
 import io.vertx.openapi.validation.ValidationContext;
-import java.util.List;
 
 public class DefaultMediaTypeRegistration implements MediaTypeRegistration {
   public static final String APPLICATION_JSON = "application/json";
@@ -29,6 +30,7 @@ public class DefaultMediaTypeRegistration implements MediaTypeRegistration {
   public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
   public static final String TEXT_PLAIN = "text/plain";
   public static final String TEXT_PLAIN_UTF8 = TEXT_PLAIN + "; charset=utf-8";
+  public static final String APPLICATION_X_WWW_FORM_URL_ENCODED = "application/x-www-form-urlencoded";
 
   private final MediaTypePredicate canHandleMediaType;
   private final ContentAnalyserFactory contentAnalyserFactory;

--- a/src/main/java/io/vertx/openapi/mediatype/impl/DefaultMediaTypeRegistration.java
+++ b/src/main/java/io/vertx/openapi/mediatype/impl/DefaultMediaTypeRegistration.java
@@ -12,8 +12,6 @@
 
 package io.vertx.openapi.mediatype.impl;
 
-import java.util.List;
-
 import io.vertx.core.buffer.Buffer;
 import io.vertx.openapi.mediatype.ContentAnalyser;
 import io.vertx.openapi.mediatype.ContentAnalyserFactory;
@@ -21,6 +19,7 @@ import io.vertx.openapi.mediatype.MediaTypeInfo;
 import io.vertx.openapi.mediatype.MediaTypePredicate;
 import io.vertx.openapi.mediatype.MediaTypeRegistration;
 import io.vertx.openapi.validation.ValidationContext;
+import java.util.List;
 
 public class DefaultMediaTypeRegistration implements MediaTypeRegistration {
   public static final String APPLICATION_JSON = "application/json";

--- a/src/main/java/io/vertx/openapi/mediatype/impl/XWwwFormUrlencodedAnalyser.java
+++ b/src/main/java/io/vertx/openapi/mediatype/impl/XWwwFormUrlencodedAnalyser.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025, Shi HaiBin
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.mediatype.impl;
+
+import static io.vertx.openapi.mediatype.impl.DefaultMediaTypeRegistration.APPLICATION_X_WWW_FORM_URL_ENCODED;
+import static io.vertx.openapi.validation.ValidatorErrorType.MISSING_REQUIRED_PARAMETER;
+
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.openapi.mediatype.MediaTypeInfo;
+import io.vertx.openapi.validation.ValidationContext;
+import io.vertx.openapi.validation.ValidatorException;
+
+public class XWwwFormUrlencodedAnalyser extends AbstractContentAnalyser {
+
+  private JsonObject parsedForm;
+
+  /**
+   * Creates a new content analyser.
+   *
+   * @param contentType the content type.
+   * @param content     the content to be analysed.
+   * @param context     the context in which the content is used.
+   */
+  public XWwwFormUrlencodedAnalyser(String contentType, Buffer content, ValidationContext context) {
+    super(contentType, content, context);
+  }
+
+  @Override
+  public void checkSyntacticalCorrectness() {
+    if (contentType == null || contentType.isEmpty()
+        || !contentType.startsWith(APPLICATION_X_WWW_FORM_URL_ENCODED)) {
+      String msg = "The expected application/x-www-form-urlencoded " + requestOrResponse
+          + " doesn't contain the required content-type header.";
+      throw new ValidatorException(msg, MISSING_REQUIRED_PARAMETER);
+    }
+
+    Charset charset = resolveCharset(contentType);
+    String body = content == null ? "" : content.toString(charset);
+    parsedForm = parseFormData(body, charset);
+  }
+
+  @Override
+  public Object transform() {
+    return parsedForm;
+  }
+
+  public static Charset resolveCharset(String contentType) {
+    if (contentType != null && contentType.contains("charset=")) {
+      String charsetName = MediaTypeInfo.of(contentType).parameters().get("charset");
+      if (charsetName != null) {
+        try {
+          return Charset.forName(charsetName);
+        } catch (IllegalCharsetNameException | UnsupportedCharsetException ignored) {
+          // fall through to default
+        }
+      }
+    }
+    return StandardCharsets.UTF_8;
+  }
+
+  private JsonObject parseFormData(String body, Charset charset) {
+    JsonObject result = new JsonObject();
+    if (body.isEmpty()) {
+      return result;
+    }
+
+    for (String pair : body.split("&")) {
+      if (pair.isEmpty()) {
+        continue;
+      }
+      int idx = pair.indexOf('=');
+      String rawKey = idx >= 0 ? pair.substring(0, idx) : pair;
+      String rawValue = idx >= 0 ? pair.substring(idx + 1) : "";
+
+      String key = URLDecoder.decode(rawKey, charset);
+      String decodedValue = URLDecoder.decode(rawValue, charset);
+      Object value = coerceValue(decodedValue);
+      // Handle array notation: key[]=value1&key[]=value2
+      if (key.endsWith("[]")) {
+        String arrayKey = key.substring(0, key.length() - 2);
+        if (!result.containsKey(arrayKey)) {
+          result.put(arrayKey, new JsonArray());
+        }
+        result.getJsonArray(arrayKey).add(value);
+      } else {
+        // Handle duplicate keys: if key already exists, convert to array
+        if (result.containsKey(key)) {
+          Object existing = result.getValue(key);
+          if (existing instanceof JsonArray) {
+            ((JsonArray) existing).add(value);
+          } else {
+            result.put(key, new JsonArray().add(existing).add(value));
+          }
+        } else {
+          result.put(key, value);
+        }
+      }
+    }
+    return result;
+  }
+
+  public static Object coerceValue(String value) {
+    try {
+      return Json.decodeValue(value);
+    } catch (DecodeException e) {
+      return value;
+    }
+  }
+}

--- a/src/main/java/io/vertx/openapi/mediatype/impl/XWwwFormUrlencodedAnalyser.java
+++ b/src/main/java/io/vertx/openapi/mediatype/impl/XWwwFormUrlencodedAnalyser.java
@@ -15,12 +15,6 @@ package io.vertx.openapi.mediatype.impl;
 import static io.vertx.openapi.mediatype.impl.DefaultMediaTypeRegistration.APPLICATION_X_WWW_FORM_URL_ENCODED;
 import static io.vertx.openapi.validation.ValidatorErrorType.MISSING_REQUIRED_PARAMETER;
 
-import java.net.URLDecoder;
-import java.nio.charset.Charset;
-import java.nio.charset.IllegalCharsetNameException;
-import java.nio.charset.StandardCharsets;
-import java.nio.charset.UnsupportedCharsetException;
-
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.Json;
@@ -29,6 +23,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.openapi.mediatype.MediaTypeInfo;
 import io.vertx.openapi.validation.ValidationContext;
 import io.vertx.openapi.validation.ValidatorException;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 
 public class XWwwFormUrlencodedAnalyser extends AbstractContentAnalyser {
 

--- a/src/test/java/io/vertx/tests/contract/impl/PathImplTest.java
+++ b/src/test/java/io/vertx/tests/contract/impl/PathImplTest.java
@@ -105,7 +105,7 @@ class PathImplTest {
     assertThat(
         new PathImpl(BASE_PATH, expected + "/", EMPTY_JSON_OBJECT, emptyList(), MediaTypeRegistry.createDefault())
             .getName())
-        .isEqualTo(expected);
+                .isEqualTo(expected);
   }
 
   @Test
@@ -113,7 +113,7 @@ class PathImplTest {
     String expected = "/";
     assertThat(
         new PathImpl(BASE_PATH, expected, EMPTY_JSON_OBJECT, emptyList(), MediaTypeRegistry.createDefault()).getName())
-        .isEqualTo(expected);
+            .isEqualTo(expected);
   }
 
   @Test

--- a/src/test/java/io/vertx/tests/contract/impl/PathImplTest.java
+++ b/src/test/java/io/vertx/tests/contract/impl/PathImplTest.java
@@ -104,7 +104,8 @@ class PathImplTest {
     String expected = "/pets";
     assertThat(
         new PathImpl(BASE_PATH, expected + "/", EMPTY_JSON_OBJECT, emptyList(), MediaTypeRegistry.createDefault())
-            .getName()).isEqualTo(expected);
+            .getName())
+        .isEqualTo(expected);
   }
 
   @Test
@@ -112,7 +113,7 @@ class PathImplTest {
     String expected = "/";
     assertThat(
         new PathImpl(BASE_PATH, expected, EMPTY_JSON_OBJECT, emptyList(), MediaTypeRegistry.createDefault()).getName())
-            .isEqualTo(expected);
+        .isEqualTo(expected);
   }
 
   @Test

--- a/src/test/java/io/vertx/tests/contract/impl/RequestBodyImplTest.java
+++ b/src/test/java/io/vertx/tests/contract/impl/RequestBodyImplTest.java
@@ -76,7 +76,7 @@ class RequestBodyImplTest {
         Arguments.of("0002_RequestBody_With_Content_Type_Application_Png", UNSUPPORTED_FEATURE,
             "The passed OpenAPI contract contains a feature that is not supported: Operation dummyOperation defines a "
                 + "request body with an unsupported media type. Supported: application/json, application/json; charset=utf-8,"
-                + " application/hal+json, multipart/form-data, application/octet-stream, text/plain, text/plain; charset=utf-8, ^[^/]+/vnd\\.[\\w.-]+\\+json$"));
+                + " application/hal+json, multipart/form-data, application/octet-stream, application/x-www-form-urlencoded, text/plain, text/plain; charset=utf-8, ^[^/]+/vnd\\.[\\w.-]+\\+json$"));
   }
 
   @ParameterizedTest(name = "{index} test getters for scenario: {0}")

--- a/src/test/java/io/vertx/tests/contract/impl/ResponseImplTest.java
+++ b/src/test/java/io/vertx/tests/contract/impl/ResponseImplTest.java
@@ -68,7 +68,7 @@ class ResponseImplTest {
         Arguments.of("0000_Response_With_Content_Type_Application_Png", UNSUPPORTED_FEATURE,
             "The passed OpenAPI contract contains a feature that is not supported: Operation dummyOperation defines a "
                 + "response with an unsupported media type. Supported: application/json, application/json; charset=utf-8, "
-                + "application/hal+json, multipart/form-data, application/octet-stream, text/plain, text/plain; charset=utf-8, ^[^/]+/vnd\\.[\\w.-]+\\+json$"));
+                + "application/hal+json, multipart/form-data, application/octet-stream, application/x-www-form-urlencoded, text/plain, text/plain; charset=utf-8, ^[^/]+/vnd\\.[\\w.-]+\\+json$"));
   }
 
   @ParameterizedTest(name = "{index} test getters for scenario: {0}")

--- a/src/test/java/io/vertx/tests/mediatype/MediaTypeRegistryTest.java
+++ b/src/test/java/io/vertx/tests/mediatype/MediaTypeRegistryTest.java
@@ -15,11 +15,12 @@ package io.vertx.tests.mediatype;
 import static com.google.common.truth.Truth.assertThat;
 import static io.vertx.openapi.mediatype.MediaTypePredicate.ofExactTypes;
 
+import org.junit.jupiter.api.Test;
+
 import io.vertx.openapi.mediatype.ContentAnalyserFactory;
 import io.vertx.openapi.mediatype.MediaTypeRegistration;
 import io.vertx.openapi.mediatype.MediaTypeRegistry;
 import io.vertx.openapi.mediatype.impl.DefaultMediaTypeRegistration;
-import org.junit.jupiter.api.Test;
 
 public class MediaTypeRegistryTest {
 
@@ -33,6 +34,7 @@ public class MediaTypeRegistryTest {
     assertThat(r.isSupported(DefaultMediaTypeRegistration.APPLICATION_HAL_JSON)).isFalse();
     assertThat(r.isSupported(DefaultMediaTypeRegistration.APPLICATION_OCTET_STREAM)).isFalse();
     assertThat(r.isSupported(DefaultMediaTypeRegistration.MULTIPART_FORM_DATA)).isFalse();
+    assertThat(r.isSupported(DefaultMediaTypeRegistration.APPLICATION_X_WWW_FORM_URL_ENCODED)).isFalse();
   }
 
   @Test
@@ -45,6 +47,7 @@ public class MediaTypeRegistryTest {
     assertThat(r.isSupported(DefaultMediaTypeRegistration.APPLICATION_HAL_JSON)).isTrue();
     assertThat(r.isSupported(DefaultMediaTypeRegistration.APPLICATION_OCTET_STREAM)).isTrue();
     assertThat(r.isSupported(DefaultMediaTypeRegistration.MULTIPART_FORM_DATA)).isTrue();
+    assertThat(r.isSupported(DefaultMediaTypeRegistration.APPLICATION_X_WWW_FORM_URL_ENCODED)).isTrue();
   }
 
   @Test

--- a/src/test/java/io/vertx/tests/mediatype/MediaTypeRegistryTest.java
+++ b/src/test/java/io/vertx/tests/mediatype/MediaTypeRegistryTest.java
@@ -15,12 +15,11 @@ package io.vertx.tests.mediatype;
 import static com.google.common.truth.Truth.assertThat;
 import static io.vertx.openapi.mediatype.MediaTypePredicate.ofExactTypes;
 
-import org.junit.jupiter.api.Test;
-
 import io.vertx.openapi.mediatype.ContentAnalyserFactory;
 import io.vertx.openapi.mediatype.MediaTypeRegistration;
 import io.vertx.openapi.mediatype.MediaTypeRegistry;
 import io.vertx.openapi.mediatype.impl.DefaultMediaTypeRegistration;
+import org.junit.jupiter.api.Test;
 
 public class MediaTypeRegistryTest {
 

--- a/src/test/java/io/vertx/tests/mediatype/impl/XWwwFormUrlencodedAnalyserTest.java
+++ b/src/test/java/io/vertx/tests/mediatype/impl/XWwwFormUrlencodedAnalyserTest.java
@@ -25,6 +25,7 @@ import io.vertx.openapi.mediatype.impl.XWwwFormUrlencodedAnalyser;
 import io.vertx.openapi.validation.ValidatorErrorType;
 import io.vertx.openapi.validation.ValidatorException;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,39 +38,24 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class XWwwFormUrlencodedAnalyserTest {
   private static final Path TEST_RESOURCE_PATH = getRelatedTestResourcePath(XWwwFormUrlencodedAnalyserTest.class);
+  private static final String APPLICATION_X_WWW_FORM_URL_ENCODED = "application/x-www-form-urlencoded";
 
-  // ==================== resolveCharset 测试 ====================
-
-  @Test
-  void testResolveCharsetWithExplicitCharset() {
-    assertThat(resolveCharset("application/x-www-form-urlencoded; charset=UTF-8"))
-        .isEqualTo(StandardCharsets.UTF_8);
+  static Stream<Arguments> testResolveCharset() {
+    return Stream.of(
+        Arguments.of(APPLICATION_X_WWW_FORM_URL_ENCODED + "; charset=UTF-8", StandardCharsets.UTF_8),
+        Arguments.of(APPLICATION_X_WWW_FORM_URL_ENCODED + "; charset=ISO-8859-1", StandardCharsets.ISO_8859_1),
+        Arguments.of(APPLICATION_X_WWW_FORM_URL_ENCODED + "; charset=invalid-charset", StandardCharsets.UTF_8),
+        Arguments.of(APPLICATION_X_WWW_FORM_URL_ENCODED, StandardCharsets.UTF_8),
+        Arguments.of(null, StandardCharsets.UTF_8));
   }
 
-  @Test
-  void testResolveCharsetWithISO8859() {
-    assertThat(resolveCharset("application/x-www-form-urlencoded; charset=ISO-8859-1"))
-        .isEqualTo(StandardCharsets.ISO_8859_1);
+  @ParameterizedTest
+  @MethodSource
+  void testResolveCharset(String contentType, Charset expected) {
+    assertThat(resolveCharset(contentType)).isEqualTo(expected);
   }
 
-  @Test
-  void testResolveCharsetInvalidCharset() {
-    assertThat(resolveCharset("application/x-www-form-urlencoded; charset=invalid-charset"))
-        .isEqualTo(StandardCharsets.UTF_8);
-  }
-
-  @Test
-  void testResolveCharsetNoCharset() {
-    assertThat(resolveCharset("application/x-www-form-urlencoded"))
-        .isEqualTo(StandardCharsets.UTF_8);
-  }
-
-  @Test
-  void testResolveCharsetNullContentType() {
-    assertThat(resolveCharset(null)).isEqualTo(StandardCharsets.UTF_8);
-  }
-
-  // ==================== checkSyntacticalCorrectness 异常测试 ====================
+  // ==================== checkSyntacticalCorrectness - exception tests ====================
 
   static Stream<Arguments> testCheckSyntacticalCorrectnessThrowIfContentTypeIsMissing() {
     return Stream.of(
@@ -91,206 +77,87 @@ class XWwwFormUrlencodedAnalyserTest {
     assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);
   }
 
-  // ==================== transform 基础测试 ====================
+  static Stream<Arguments> testTransform() {
+    return Stream.of(
+        Arguments.of("basic form data",
+            "client_id=26d0bcefd30a4f27897eb9b0e89b53d9&username=admin&password=test123",
+            new JsonObject()
+                .put("client_id", "26d0bcefd30a4f27897eb9b0e89b53d9")
+                .put("username", "admin")
+                .put("password", "test123")),
+        Arguments.of("URL encoding",
+            "email=user%40example.com&message=hello%20world&special=%26%3D%2F",
+            new JsonObject()
+                .put("email", "user@example.com")
+                .put("message", "hello world")
+                .put("special", "&=/")),
+        Arguments.of("array notation",
+            "tags[]=java&tags[]=vertx&tags[]=openapi",
+            new JsonObject()
+                .put("tags", new JsonArray().add("java").add("vertx").add("openapi"))),
+        Arguments.of("duplicate keys",
+            "key=value1&key=value2&key=value3",
+            new JsonObject()
+                .put("key", new JsonArray().add("value1").add("value2").add("value3"))),
+        Arguments.of("mixed array notation and duplicate keys",
+            "items[]=a&items=b&items[]=c",
+            new JsonObject()
+                .put("items", new JsonArray().add("a").add("b").add("c"))),
+        Arguments.of("empty body",
+            "",
+            new JsonObject()),
+        Arguments.of("null body",
+            null,
+            new JsonObject()),
+        Arguments.of("key without value",
+            "key1&key2=value2",
+            new JsonObject()
+                .put("key1", "")
+                .put("key2", "value2")),
+        Arguments.of("value with equals sign",
+            "equation=1%2B1=2&url=http://example.com?a=1%26b=2",
+            new JsonObject()
+                .put("equation", "1+1=2")
+                .put("url", "http://example.com?a=1&b=2")),
+        Arguments.of("JSON object value",
+            "data=%7B%22nested%22%3A%22value%22%2C%22num%22%3A123%7D",
+            new JsonObject()
+                .put("data", new JsonObject().put("nested", "value").put("num", 123))),
+        Arguments.of("JSON array value",
+            "items=%5B1%2C2%2C3%5D&name=test",
+            new JsonObject()
+                .put("items", new JsonArray().add(1).add(2).add(3))
+                .put("name", "test")),
+        Arguments.of("real-world login request",
+            "client_id=26d0bcefd30a4f27897eb9b0e89b53d9"
+                + "&client_secret=76erkSZyFOgBVMDmVlZ5CJpLkOtOly1ufRKK8JiAvArI7rXo3y76DsfyzXE2FJl1"
+                + "&username=admin"
+                + "&password=Vertx%402026",
+            new JsonObject()
+                .put("client_id", "26d0bcefd30a4f27897eb9b0e89b53d9")
+                .put("client_secret", "76erkSZyFOgBVMDmVlZ5CJpLkOtOly1ufRKK8JiAvArI7rXo3y76DsfyzXE2FJl1")
+                .put("username", "admin")
+                .put("password", "Vertx@2026")));
+  }
 
-  @Test
-  void testTransformBasicFormData() {
-    String body = "client_id=26d0bcefd30a4f27897eb9b0e89b53d9&username=admin&password=test123";
-    Buffer buffer = Buffer.buffer(body);
-    String contentType = "application/x-www-form-urlencoded";
+  @ParameterizedTest(name = "{0}")
+  @MethodSource
+  void testTransform(String description, String body, JsonObject expected) {
+    Buffer buffer = body != null ? Buffer.buffer(body) : null;
 
-    JsonObject expected = new JsonObject()
-        .put("client_id", "26d0bcefd30a4f27897eb9b0e89b53d9")
-        .put("username", "admin")
-        .put("password", "test123");
-
-    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    XWwwFormUrlencodedAnalyser analyser =
+        new XWwwFormUrlencodedAnalyser(APPLICATION_X_WWW_FORM_URL_ENCODED, buffer, REQUEST);
     analyser.checkSyntacticalCorrectness();
 
     assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
   }
 
-  @Test
-  void testTransformWithUrlEncoding() {
-    String body = "email=user%40example.com&message=hello%20world&special=%26%3D%2F";
-    Buffer buffer = Buffer.buffer(body);
-    String contentType = "application/x-www-form-urlencoded";
-
-    JsonObject expected = new JsonObject()
-        .put("email", "user@example.com")
-        .put("message", "hello world")
-        .put("special", "&=/");
-
-    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
-    analyser.checkSyntacticalCorrectness();
-
-    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
-  }
-
-  // ==================== transform 数组标记测试 ====================
-
-  @Test
-  void testTransformWithArrayNotation() {
-    String body = "tags[]=java&tags[]=vertx&tags[]=openapi";
-    Buffer buffer = Buffer.buffer(body);
-    String contentType = "application/x-www-form-urlencoded";
-
-    JsonObject expected = new JsonObject()
-        .put("tags", new JsonArray().add("java").add("vertx").add("openapi"));
-
-    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
-    analyser.checkSyntacticalCorrectness();
-
-    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
-  }
-
-  @Test
-  void testTransformWithDuplicateKeys() {
-    String body = "key=value1&key=value2&key=value3";
-    Buffer buffer = Buffer.buffer(body);
-    String contentType = "application/x-www-form-urlencoded";
-
-    JsonObject expected = new JsonObject()
-        .put("key", new JsonArray().add("value1").add("value2").add("value3"));
-
-    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
-    analyser.checkSyntacticalCorrectness();
-
-    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
-  }
-
-  @Test
-  void testTransformMixedArrayNotationAndDuplicate() {
-    String body = "items[]=a&items=b&items[]=c";
-    Buffer buffer = Buffer.buffer(body);
-    String contentType = "application/x-www-form-urlencoded";
-
-    JsonObject expected = new JsonObject()
-        .put("items", new JsonArray().add("a").add("b").add("c"));
-
-    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
-    analyser.checkSyntacticalCorrectness();
-
-    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
-  }
-
-  // ==================== transform 边界条件测试 ====================
-
-  @Test
-  void testTransformEmptyBody() {
-    Buffer buffer = Buffer.buffer("");
-    String contentType = "application/x-www-form-urlencoded";
-
-    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
-    analyser.checkSyntacticalCorrectness();
-
-    assertThat((JsonObject) analyser.transform()).isEqualTo(new JsonObject());
-  }
-
-  @Test
-  void testTransformNullBody() {
-    String contentType = "application/x-www-form-urlencoded";
-
-    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, null, REQUEST);
-    analyser.checkSyntacticalCorrectness();
-
-    assertThat((JsonObject) analyser.transform()).isEqualTo(new JsonObject());
-  }
-
-  @Test
-  void testTransformKeyWithoutValue() {
-    String body = "key1&key2=value2";
-    Buffer buffer = Buffer.buffer(body);
-    String contentType = "application/x-www-form-urlencoded";
-
-    JsonObject expected = new JsonObject()
-        .put("key1", "")
-        .put("key2", "value2");
-
-    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
-    analyser.checkSyntacticalCorrectness();
-
-    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
-  }
-
-  @Test
-  void testTransformValueWithEquals() {
-    String body = "equation=1%2B1=2&url=http://example.com?a=1%26b=2";
-    Buffer buffer = Buffer.buffer(body);
-    String contentType = "application/x-www-form-urlencoded";
-
-    JsonObject expected = new JsonObject()
-        .put("equation", "1+1=2")
-        .put("url", "http://example.com?a=1&b=2");
-
-    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
-    analyser.checkSyntacticalCorrectness();
-
-    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
-  }
-
-  // ==================== transform JSON 值测试 ====================
-
-  @Test
-  void testTransformWithJsonObjectValue() {
-    String body = "data=%7B%22nested%22%3A%22value%22%2C%22num%22%3A123%7D";
-    Buffer buffer = Buffer.buffer(body);
-    String contentType = "application/x-www-form-urlencoded";
-
-    JsonObject expected = new JsonObject()
-        .put("data", new JsonObject().put("nested", "value").put("num", 123));
-
-    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
-    analyser.checkSyntacticalCorrectness();
-
-    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
-  }
-
-  @Test
-  void testTransformWithJsonArrayValue() {
-    String body = "items=%5B1%2C2%2C3%5D&name=test";
-    Buffer buffer = Buffer.buffer(body);
-    String contentType = "application/x-www-form-urlencoded";
-
-    JsonObject expected = new JsonObject()
-        .put("items", new JsonArray().add(1).add(2).add(3))
-        .put("name", "test");
-
-    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
-    analyser.checkSyntacticalCorrectness();
-
-    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
-  }
-
-  // ==================== 真实登录请求场景测试 ====================
-
-  @Test
-  void testTransformLoginExample() {
-    String body = "client_id=26d0bcefd30a4f27897eb9b0e89b53d9" +
-        "&client_secret=76erkSZyFOgBVMDmVlZ5CJpLkOtOly1ufRKK8JiAvArI7rXo3y76DsfyzXE2FJl1" +
-        "&username=admin" +
-        "&password=Vertx%402026";
-    Buffer buffer = Buffer.buffer(body);
-    String contentType = "application/x-www-form-urlencoded";
-
-    JsonObject expected = new JsonObject()
-        .put("client_id", "26d0bcefd30a4f27897eb9b0e89b53d9")
-        .put("client_secret", "76erkSZyFOgBVMDmVlZ5CJpLkOtOly1ufRKK8JiAvArI7rXo3y76DsfyzXE2FJl1")
-        .put("username", "admin")
-        .put("password", "Vertx@2026");
-
-    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
-    analyser.checkSyntacticalCorrectness();
-
-    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
-  }
-
-  // ==================== Content-Type 变体测试 ====================
+  // ==================== transform - Content-Type variant tests ====================
 
   @ParameterizedTest
   @ValueSource(strings = {
-      "application/x-www-form-urlencoded",
-      "application/x-www-form-urlencoded; charset=UTF-8",
+      APPLICATION_X_WWW_FORM_URL_ENCODED,
+      APPLICATION_X_WWW_FORM_URL_ENCODED + "; charset=UTF-8",
   })
   void testTransformWithVariousContentTypes(String contentType) {
     String body = "key=value";
@@ -303,12 +170,11 @@ class XWwwFormUrlencodedAnalyserTest {
     assertThat(result.getString("key")).isEqualTo("value");
   }
 
-  // ==================== 复杂场景测试 ====================
+  // ==================== transform - complex scenario tests ====================
 
   @Test
   void testTransformComplexScenario() throws IOException {
     Buffer buffer = Buffer.buffer(Files.readString(TEST_RESOURCE_PATH.resolve("form_urlencoded_complex.txt")));
-    String contentType = "application/x-www-form-urlencoded";
 
     JsonObject expected = new JsonObject()
         .put("grant_type", "password")
@@ -316,7 +182,8 @@ class XWwwFormUrlencodedAnalyserTest {
         .put("roles", new JsonArray().add("admin").add("user"))
         .put("settings", new JsonObject().put("theme", "dark").put("notifications", true));
 
-    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    XWwwFormUrlencodedAnalyser analyser =
+        new XWwwFormUrlencodedAnalyser(APPLICATION_X_WWW_FORM_URL_ENCODED, buffer, REQUEST);
     analyser.checkSyntacticalCorrectness();
 
     assertThat((JsonObject) analyser.transform()).isEqualTo(expected);

--- a/src/test/java/io/vertx/tests/mediatype/impl/XWwwFormUrlencodedAnalyserTest.java
+++ b/src/test/java/io/vertx/tests/mediatype/impl/XWwwFormUrlencodedAnalyserTest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2025, Shi HaiBin
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.tests.mediatype.impl;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.vertx.openapi.mediatype.impl.XWwwFormUrlencodedAnalyser.resolveCharset;
+import static io.vertx.openapi.validation.ValidationContext.REQUEST;
+import static io.vertx.tests.ResourceHelper.getRelatedTestResourcePath;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.openapi.mediatype.impl.XWwwFormUrlencodedAnalyser;
+import io.vertx.openapi.validation.ValidatorErrorType;
+import io.vertx.openapi.validation.ValidatorException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class XWwwFormUrlencodedAnalyserTest {
+  private static final Path TEST_RESOURCE_PATH = getRelatedTestResourcePath(XWwwFormUrlencodedAnalyserTest.class);
+
+  // ==================== resolveCharset 测试 ====================
+
+  @Test
+  void testResolveCharsetWithExplicitCharset() {
+    assertThat(resolveCharset("application/x-www-form-urlencoded; charset=UTF-8"))
+        .isEqualTo(StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void testResolveCharsetWithISO8859() {
+    assertThat(resolveCharset("application/x-www-form-urlencoded; charset=ISO-8859-1"))
+        .isEqualTo(StandardCharsets.ISO_8859_1);
+  }
+
+  @Test
+  void testResolveCharsetInvalidCharset() {
+    assertThat(resolveCharset("application/x-www-form-urlencoded; charset=invalid-charset"))
+        .isEqualTo(StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void testResolveCharsetNoCharset() {
+    assertThat(resolveCharset("application/x-www-form-urlencoded"))
+        .isEqualTo(StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void testResolveCharsetNullContentType() {
+    assertThat(resolveCharset(null)).isEqualTo(StandardCharsets.UTF_8);
+  }
+
+  // ==================== checkSyntacticalCorrectness 异常测试 ====================
+
+  static Stream<Arguments> testCheckSyntacticalCorrectnessThrowIfContentTypeIsMissing() {
+    return Stream.of(
+        Arguments.of((String) null),
+        Arguments.of(""),
+        Arguments.of("application/json"),
+        Arguments.of("text/plain"));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testCheckSyntacticalCorrectnessThrowIfContentTypeIsMissing(String contentType) {
+    ValidatorException exception = assertThrows(ValidatorException.class,
+        () -> new XWwwFormUrlencodedAnalyser(contentType, null, REQUEST).checkSyntacticalCorrectness());
+
+    String expectedMsg =
+        "The expected application/x-www-form-urlencoded request doesn't contain the required content-type header.";
+    assertThat(exception.type()).isEqualTo(ValidatorErrorType.MISSING_REQUIRED_PARAMETER);
+    assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);
+  }
+
+  // ==================== transform 基础测试 ====================
+
+  @Test
+  void testTransformBasicFormData() {
+    String body = "client_id=26d0bcefd30a4f27897eb9b0e89b53d9&username=admin&password=test123";
+    Buffer buffer = Buffer.buffer(body);
+    String contentType = "application/x-www-form-urlencoded";
+
+    JsonObject expected = new JsonObject()
+        .put("client_id", "26d0bcefd30a4f27897eb9b0e89b53d9")
+        .put("username", "admin")
+        .put("password", "test123");
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
+  }
+
+  @Test
+  void testTransformWithUrlEncoding() {
+    String body = "email=user%40example.com&message=hello%20world&special=%26%3D%2F";
+    Buffer buffer = Buffer.buffer(body);
+    String contentType = "application/x-www-form-urlencoded";
+
+    JsonObject expected = new JsonObject()
+        .put("email", "user@example.com")
+        .put("message", "hello world")
+        .put("special", "&=/");
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
+  }
+
+  // ==================== transform 数组标记测试 ====================
+
+  @Test
+  void testTransformWithArrayNotation() {
+    String body = "tags[]=java&tags[]=vertx&tags[]=openapi";
+    Buffer buffer = Buffer.buffer(body);
+    String contentType = "application/x-www-form-urlencoded";
+
+    JsonObject expected = new JsonObject()
+        .put("tags", new JsonArray().add("java").add("vertx").add("openapi"));
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
+  }
+
+  @Test
+  void testTransformWithDuplicateKeys() {
+    String body = "key=value1&key=value2&key=value3";
+    Buffer buffer = Buffer.buffer(body);
+    String contentType = "application/x-www-form-urlencoded";
+
+    JsonObject expected = new JsonObject()
+        .put("key", new JsonArray().add("value1").add("value2").add("value3"));
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
+  }
+
+  @Test
+  void testTransformMixedArrayNotationAndDuplicate() {
+    String body = "items[]=a&items=b&items[]=c";
+    Buffer buffer = Buffer.buffer(body);
+    String contentType = "application/x-www-form-urlencoded";
+
+    JsonObject expected = new JsonObject()
+        .put("items", new JsonArray().add("a").add("b").add("c"));
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
+  }
+
+  // ==================== transform 边界条件测试 ====================
+
+  @Test
+  void testTransformEmptyBody() {
+    Buffer buffer = Buffer.buffer("");
+    String contentType = "application/x-www-form-urlencoded";
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(new JsonObject());
+  }
+
+  @Test
+  void testTransformNullBody() {
+    String contentType = "application/x-www-form-urlencoded";
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, null, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(new JsonObject());
+  }
+
+  @Test
+  void testTransformKeyWithoutValue() {
+    String body = "key1&key2=value2";
+    Buffer buffer = Buffer.buffer(body);
+    String contentType = "application/x-www-form-urlencoded";
+
+    JsonObject expected = new JsonObject()
+        .put("key1", "")
+        .put("key2", "value2");
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
+  }
+
+  @Test
+  void testTransformValueWithEquals() {
+    String body = "equation=1%2B1=2&url=http://example.com?a=1%26b=2";
+    Buffer buffer = Buffer.buffer(body);
+    String contentType = "application/x-www-form-urlencoded";
+
+    JsonObject expected = new JsonObject()
+        .put("equation", "1+1=2")
+        .put("url", "http://example.com?a=1&b=2");
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
+  }
+
+  // ==================== transform JSON 值测试 ====================
+
+  @Test
+  void testTransformWithJsonObjectValue() {
+    String body = "data=%7B%22nested%22%3A%22value%22%2C%22num%22%3A123%7D";
+    Buffer buffer = Buffer.buffer(body);
+    String contentType = "application/x-www-form-urlencoded";
+
+    JsonObject expected = new JsonObject()
+        .put("data", new JsonObject().put("nested", "value").put("num", 123));
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
+  }
+
+  @Test
+  void testTransformWithJsonArrayValue() {
+    String body = "items=%5B1%2C2%2C3%5D&name=test";
+    Buffer buffer = Buffer.buffer(body);
+    String contentType = "application/x-www-form-urlencoded";
+
+    JsonObject expected = new JsonObject()
+        .put("items", new JsonArray().add(1).add(2).add(3))
+        .put("name", "test");
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
+  }
+
+  // ==================== 真实登录请求场景测试 ====================
+
+  @Test
+  void testTransformLoginExample() {
+    String body = "client_id=26d0bcefd30a4f27897eb9b0e89b53d9" +
+        "&client_secret=76erkSZyFOgBVMDmVlZ5CJpLkOtOly1ufRKK8JiAvArI7rXo3y76DsfyzXE2FJl1" +
+        "&username=admin" +
+        "&password=Vertx%402026";
+    Buffer buffer = Buffer.buffer(body);
+    String contentType = "application/x-www-form-urlencoded";
+
+    JsonObject expected = new JsonObject()
+        .put("client_id", "26d0bcefd30a4f27897eb9b0e89b53d9")
+        .put("client_secret", "76erkSZyFOgBVMDmVlZ5CJpLkOtOly1ufRKK8JiAvArI7rXo3y76DsfyzXE2FJl1")
+        .put("username", "admin")
+        .put("password", "Vertx@2026");
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
+  }
+
+  // ==================== Content-Type 变体测试 ====================
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "application/x-www-form-urlencoded",
+      "application/x-www-form-urlencoded; charset=UTF-8",
+  })
+  void testTransformWithVariousContentTypes(String contentType) {
+    String body = "key=value";
+    Buffer buffer = Buffer.buffer(body);
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    JsonObject result = (JsonObject) analyser.transform();
+    assertThat(result.getString("key")).isEqualTo("value");
+  }
+
+  // ==================== 复杂场景测试 ====================
+
+  @Test
+  void testTransformComplexScenario() throws IOException {
+    Buffer buffer = Buffer.buffer(Files.readString(TEST_RESOURCE_PATH.resolve("form_urlencoded_complex.txt")));
+    String contentType = "application/x-www-form-urlencoded";
+
+    JsonObject expected = new JsonObject()
+        .put("grant_type", "password")
+        .put("scope", "read:user write:user")
+        .put("roles", new JsonArray().add("admin").add("user"))
+        .put("settings", new JsonObject().put("theme", "dark").put("notifications", true));
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
+  }
+}

--- a/src/test/java/io/vertx/tests/validation/ExtractReasonTest.java
+++ b/src/test/java/io/vertx/tests/validation/ExtractReasonTest.java
@@ -108,7 +108,7 @@ class ExtractReasonTest extends HttpServerTestBase {
     createValidationHandler(
         validatorException -> Truth.assertThat(validatorException).hasMessageThat().endsWith(expected),
         testContext)
-            .compose(v -> sendJson(payload.toBuffer())).onFailure(testContext::failNow);
+        .compose(v -> sendJson(payload.toBuffer())).onFailure(testContext::failNow);
   }
 
   @Test

--- a/src/test/java/io/vertx/tests/validation/ExtractReasonTest.java
+++ b/src/test/java/io/vertx/tests/validation/ExtractReasonTest.java
@@ -108,7 +108,7 @@ class ExtractReasonTest extends HttpServerTestBase {
     createValidationHandler(
         validatorException -> Truth.assertThat(validatorException).hasMessageThat().endsWith(expected),
         testContext)
-        .compose(v -> sendJson(payload.toBuffer())).onFailure(testContext::failNow);
+            .compose(v -> sendJson(payload.toBuffer())).onFailure(testContext::failNow);
   }
 
   @Test

--- a/src/test/resources/io/vertx/tests/mediatype/impl/form_urlencoded_complex.txt
+++ b/src/test/resources/io/vertx/tests/mediatype/impl/form_urlencoded_complex.txt
@@ -1,0 +1,1 @@
+grant_type=password&scope=read:user write:user&roles[]=admin&roles[]=user&settings=%7B%22theme%22%3A%22dark%22%2C%22notifications%22%3Atrue%7D


### PR DESCRIPTION
Motivation:

application/x-www-form-urlencoded is not included in the default media type registry, which causes issues when implementing OAuth2 token endpoints (RFC 6749 requires this media type).

Conformance:
Added complete support for application/x-www-form-urlencoded media type with a dedicated content analyser.

Changes Made
New Files:

XWwwFormUrlencodedAnalyser.java - Content analyser implementation for form-urlencoded data
Modified Files:

MediaTypeRegistration.java - Added form-urlencoded media type registration constants
MediaTypeRegistry.java - Registered the new media type in default registry
ContentAnalyserFactory.java - Added XWwwFormUrlencodedAnalyser to analyser factory
MediaTypeRegistryTest.java - Added unit tests for the new media type
Testing
✅ Unit tests added in MediaTypeRegistryTest
✅ Manually tested in a local project (OAuth2 token endpoint scenario)
- [ ] Awaiting your review