### PR TITLE
Added support for application/x-www-form-urlencoded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ hs_err_pid*
 vertx-json-validator.iml
 .idea/
 *.iml
+.vscode/settings.json

--- a/src/main/java/io/vertx/openapi/mediatype/ContentAnalyserFactory.java
+++ b/src/main/java/io/vertx/openapi/mediatype/ContentAnalyserFactory.java
@@ -17,6 +17,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.openapi.mediatype.impl.ApplicationJsonAnalyser;
 import io.vertx.openapi.mediatype.impl.MultipartFormAnalyser;
 import io.vertx.openapi.mediatype.impl.NoOpAnalyser;
+import io.vertx.openapi.mediatype.impl.XWwwFormUrlencodedAnalyser;
 import io.vertx.openapi.validation.ValidationContext;
 
 @VertxGen
@@ -42,5 +43,9 @@ public interface ContentAnalyserFactory {
 
   static ContentAnalyserFactory multipart() {
     return MultipartFormAnalyser::new;
+  }
+
+  static ContentAnalyserFactory xWwwFormUrlencoded() {
+    return XWwwFormUrlencodedAnalyser::new;
   }
 }

--- a/src/main/java/io/vertx/openapi/mediatype/MediaTypeRegistration.java
+++ b/src/main/java/io/vertx/openapi/mediatype/MediaTypeRegistration.java
@@ -47,6 +47,10 @@ public interface MediaTypeRegistration {
       MediaTypePredicate.ofExactTypes(DefaultMediaTypeRegistration.APPLICATION_OCTET_STREAM),
       ContentAnalyserFactory.noop());
 
+  MediaTypeRegistration APPLICATION_X_WWW_FORM_URL_ENCODED = new DefaultMediaTypeRegistration(
+      MediaTypePredicate.ofExactTypes(DefaultMediaTypeRegistration.APPLICATION_X_WWW_FORM_URL_ENCODED),
+      ContentAnalyserFactory.xWwwFormUrlencoded());
+
   MediaTypeRegistration VENDOR_SPECIFIC_JSON = new DefaultMediaTypeRegistration(
       MediaTypePredicate.ofRegexp(Pattern.compile("^[^/]+/vnd\\.[\\w.-]+\\+json$").pattern()),
       ContentAnalyserFactory.json());

--- a/src/main/java/io/vertx/openapi/mediatype/MediaTypeRegistry.java
+++ b/src/main/java/io/vertx/openapi/mediatype/MediaTypeRegistry.java
@@ -32,6 +32,7 @@ public interface MediaTypeRegistry {
         .register(MediaTypeRegistration.APPLICATION_JSON)
         .register(MediaTypeRegistration.MULTIPART_FORM_DATA)
         .register(MediaTypeRegistration.APPLICATION_OCTET_STREAM)
+        .register(MediaTypeRegistration.APPLICATION_X_WWW_FORM_URL_ENCODED)
         .register(MediaTypeRegistration.TEXT_PLAIN)
         .register(MediaTypeRegistration.VENDOR_SPECIFIC_JSON);
   }

--- a/src/main/java/io/vertx/openapi/mediatype/impl/DefaultMediaTypeRegistration.java
+++ b/src/main/java/io/vertx/openapi/mediatype/impl/DefaultMediaTypeRegistration.java
@@ -29,6 +29,7 @@ public class DefaultMediaTypeRegistration implements MediaTypeRegistration {
   public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
   public static final String TEXT_PLAIN = "text/plain";
   public static final String TEXT_PLAIN_UTF8 = TEXT_PLAIN + "; charset=utf-8";
+  public static final String APPLICATION_X_WWW_FORM_URL_ENCODED = "application/x-www-form-urlencoded";
 
   private final MediaTypePredicate canHandleMediaType;
   private final ContentAnalyserFactory contentAnalyserFactory;

--- a/src/main/java/io/vertx/openapi/mediatype/impl/XWwwFormUrlencodedAnalyser.java
+++ b/src/main/java/io/vertx/openapi/mediatype/impl/XWwwFormUrlencodedAnalyser.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2025, Shi HaiBin
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.openapi.mediatype.impl;
+
+import static io.vertx.openapi.mediatype.impl.DefaultMediaTypeRegistration.APPLICATION_X_WWW_FORM_URL_ENCODED;
+import static io.vertx.openapi.validation.ValidatorErrorType.MISSING_REQUIRED_PARAMETER;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.openapi.mediatype.MediaTypeInfo;
+import io.vertx.openapi.validation.ValidationContext;
+import io.vertx.openapi.validation.ValidatorException;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
+
+public class XWwwFormUrlencodedAnalyser extends AbstractContentAnalyser {
+
+  private JsonObject parsedForm;
+
+  /**
+   * Creates a new content analyser.
+   *
+   * @param contentType the content type.
+   * @param content     the content to be analysed.
+   * @param context     the context in which the content is used.
+   */
+  public XWwwFormUrlencodedAnalyser(String contentType, Buffer content, ValidationContext context) {
+    super(contentType, content, context);
+  }
+
+  @Override
+  public void checkSyntacticalCorrectness() {
+    if (contentType == null || contentType.isEmpty()
+        || !contentType.startsWith(APPLICATION_X_WWW_FORM_URL_ENCODED)) {
+      String msg = "The expected application/x-www-form-urlencoded " + requestOrResponse
+          + " doesn't contain the required content-type header.";
+      throw new ValidatorException(msg, MISSING_REQUIRED_PARAMETER);
+    }
+
+    Charset charset = resolveCharset(contentType);
+    String body = content == null ? "" : content.toString(charset);
+    parsedForm = parseFormData(body, charset);
+  }
+
+  @Override
+  public Object transform() {
+    return parsedForm;
+  }
+
+  public static Charset resolveCharset(String contentType) {
+    if (contentType != null && contentType.contains("charset=")) {
+      String charsetName = MediaTypeInfo.of(contentType).parameters().get("charset");
+      if (charsetName != null) {
+        try {
+          return Charset.forName(charsetName);
+        } catch (IllegalCharsetNameException | UnsupportedCharsetException ignored) {
+          // fall through to default
+        }
+      }
+    }
+    return StandardCharsets.UTF_8;
+  }
+
+  private JsonObject parseFormData(String body, Charset charset) {
+    JsonObject result = new JsonObject();
+    if (body.isEmpty()) {
+      return result;
+    }
+
+    for (String pair : body.split("&")) {
+      if (pair.isEmpty()) {
+        continue;
+      }
+      int idx = pair.indexOf('=');
+      String rawKey = idx >= 0 ? pair.substring(0, idx) : pair;
+      String rawValue = idx >= 0 ? pair.substring(idx + 1) : "";
+
+      String key = URLDecoder.decode(rawKey, charset);
+      String decodedValue = URLDecoder.decode(rawValue, charset);
+      Object value = coerceValue(decodedValue);
+      // Handle array notation: key[]=value1&key[]=value2
+      if (key.endsWith("[]")) {
+        String arrayKey = key.substring(0, key.length() - 2);
+        if (!result.containsKey(arrayKey)) {
+          result.put(arrayKey, new JsonArray());
+        }
+        result.getJsonArray(arrayKey).add(value);
+      } else {
+        // Handle duplicate keys: if key already exists, convert to array
+        if (result.containsKey(key)) {
+          Object existing = result.getValue(key);
+          if (existing instanceof JsonArray) {
+            ((JsonArray) existing).add(value);
+          } else {
+            result.put(key, new JsonArray().add(existing).add(value));
+          }
+        } else {
+          result.put(key, value);
+        }
+      }
+    }
+    return result;
+  }
+
+  public static Object coerceValue(String value) {
+    try {
+      return Json.decodeValue(value);
+    } catch (DecodeException e) {
+      return value;
+    }
+  }
+}

--- a/src/test/java/io/vertx/tests/contract/impl/RequestBodyImplTest.java
+++ b/src/test/java/io/vertx/tests/contract/impl/RequestBodyImplTest.java
@@ -76,7 +76,7 @@ class RequestBodyImplTest {
         Arguments.of("0002_RequestBody_With_Content_Type_Application_Png", UNSUPPORTED_FEATURE,
             "The passed OpenAPI contract contains a feature that is not supported: Operation dummyOperation defines a "
                 + "request body with an unsupported media type. Supported: application/json, application/json; charset=utf-8,"
-                + " application/hal+json, multipart/form-data, application/octet-stream, text/plain, text/plain; charset=utf-8, ^[^/]+/vnd\\.[\\w.-]+\\+json$"));
+                + " application/hal+json, multipart/form-data, application/octet-stream, application/x-www-form-urlencoded, text/plain, text/plain; charset=utf-8, ^[^/]+/vnd\\.[\\w.-]+\\+json$"));
   }
 
   @ParameterizedTest(name = "{index} test getters for scenario: {0}")

--- a/src/test/java/io/vertx/tests/contract/impl/ResponseImplTest.java
+++ b/src/test/java/io/vertx/tests/contract/impl/ResponseImplTest.java
@@ -68,7 +68,7 @@ class ResponseImplTest {
         Arguments.of("0000_Response_With_Content_Type_Application_Png", UNSUPPORTED_FEATURE,
             "The passed OpenAPI contract contains a feature that is not supported: Operation dummyOperation defines a "
                 + "response with an unsupported media type. Supported: application/json, application/json; charset=utf-8, "
-                + "application/hal+json, multipart/form-data, application/octet-stream, text/plain, text/plain; charset=utf-8, ^[^/]+/vnd\\.[\\w.-]+\\+json$"));
+                + "application/hal+json, multipart/form-data, application/octet-stream, application/x-www-form-urlencoded, text/plain, text/plain; charset=utf-8, ^[^/]+/vnd\\.[\\w.-]+\\+json$"));
   }
 
   @ParameterizedTest(name = "{index} test getters for scenario: {0}")

--- a/src/test/java/io/vertx/tests/mediatype/MediaTypeRegistryTest.java
+++ b/src/test/java/io/vertx/tests/mediatype/MediaTypeRegistryTest.java
@@ -33,6 +33,7 @@ public class MediaTypeRegistryTest {
     assertThat(r.isSupported(DefaultMediaTypeRegistration.APPLICATION_HAL_JSON)).isFalse();
     assertThat(r.isSupported(DefaultMediaTypeRegistration.APPLICATION_OCTET_STREAM)).isFalse();
     assertThat(r.isSupported(DefaultMediaTypeRegistration.MULTIPART_FORM_DATA)).isFalse();
+    assertThat(r.isSupported(DefaultMediaTypeRegistration.APPLICATION_X_WWW_FORM_URL_ENCODED)).isFalse();
   }
 
   @Test
@@ -45,6 +46,7 @@ public class MediaTypeRegistryTest {
     assertThat(r.isSupported(DefaultMediaTypeRegistration.APPLICATION_HAL_JSON)).isTrue();
     assertThat(r.isSupported(DefaultMediaTypeRegistration.APPLICATION_OCTET_STREAM)).isTrue();
     assertThat(r.isSupported(DefaultMediaTypeRegistration.MULTIPART_FORM_DATA)).isTrue();
+    assertThat(r.isSupported(DefaultMediaTypeRegistration.APPLICATION_X_WWW_FORM_URL_ENCODED)).isTrue();
   }
 
   @Test

--- a/src/test/java/io/vertx/tests/mediatype/impl/XWwwFormUrlencodedAnalyserTest.java
+++ b/src/test/java/io/vertx/tests/mediatype/impl/XWwwFormUrlencodedAnalyserTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2025, Shi HaiBin
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ */
+
+package io.vertx.tests.mediatype.impl;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.vertx.openapi.mediatype.impl.XWwwFormUrlencodedAnalyser.resolveCharset;
+import static io.vertx.openapi.validation.ValidationContext.REQUEST;
+import static io.vertx.tests.ResourceHelper.getRelatedTestResourcePath;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.openapi.mediatype.impl.XWwwFormUrlencodedAnalyser;
+import io.vertx.openapi.validation.ValidatorErrorType;
+import io.vertx.openapi.validation.ValidatorException;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class XWwwFormUrlencodedAnalyserTest {
+  private static final Path TEST_RESOURCE_PATH = getRelatedTestResourcePath(XWwwFormUrlencodedAnalyserTest.class);
+  private static final String APPLICATION_X_WWW_FORM_URL_ENCODED = "application/x-www-form-urlencoded";
+
+  static Stream<Arguments> testResolveCharset() {
+    return Stream.of(
+        Arguments.of(APPLICATION_X_WWW_FORM_URL_ENCODED + "; charset=UTF-8", StandardCharsets.UTF_8),
+        Arguments.of(APPLICATION_X_WWW_FORM_URL_ENCODED + "; charset=ISO-8859-1", StandardCharsets.ISO_8859_1),
+        Arguments.of(APPLICATION_X_WWW_FORM_URL_ENCODED + "; charset=invalid-charset", StandardCharsets.UTF_8),
+        Arguments.of(APPLICATION_X_WWW_FORM_URL_ENCODED, StandardCharsets.UTF_8),
+        Arguments.of(null, StandardCharsets.UTF_8));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testResolveCharset(String contentType, Charset expected) {
+    assertThat(resolveCharset(contentType)).isEqualTo(expected);
+  }
+
+  // ==================== checkSyntacticalCorrectness - exception tests ====================
+
+  static Stream<Arguments> testCheckSyntacticalCorrectnessThrowIfContentTypeIsMissing() {
+    return Stream.of(
+        Arguments.of((String) null),
+        Arguments.of(""),
+        Arguments.of("application/json"),
+        Arguments.of("text/plain"));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testCheckSyntacticalCorrectnessThrowIfContentTypeIsMissing(String contentType) {
+    ValidatorException exception = assertThrows(ValidatorException.class,
+        () -> new XWwwFormUrlencodedAnalyser(contentType, null, REQUEST).checkSyntacticalCorrectness());
+
+    String expectedMsg =
+        "The expected application/x-www-form-urlencoded request doesn't contain the required content-type header.";
+    assertThat(exception.type()).isEqualTo(ValidatorErrorType.MISSING_REQUIRED_PARAMETER);
+    assertThat(exception).hasMessageThat().isEqualTo(expectedMsg);
+  }
+
+  static Stream<Arguments> testTransform() {
+    return Stream.of(
+        Arguments.of("basic form data",
+            "client_id=26d0bcefd30a4f27897eb9b0e89b53d9&username=admin&password=test123",
+            new JsonObject()
+                .put("client_id", "26d0bcefd30a4f27897eb9b0e89b53d9")
+                .put("username", "admin")
+                .put("password", "test123")),
+        Arguments.of("URL encoding",
+            "email=user%40example.com&message=hello%20world&special=%26%3D%2F",
+            new JsonObject()
+                .put("email", "user@example.com")
+                .put("message", "hello world")
+                .put("special", "&=/")),
+        Arguments.of("array notation",
+            "tags[]=java&tags[]=vertx&tags[]=openapi",
+            new JsonObject()
+                .put("tags", new JsonArray().add("java").add("vertx").add("openapi"))),
+        Arguments.of("duplicate keys",
+            "key=value1&key=value2&key=value3",
+            new JsonObject()
+                .put("key", new JsonArray().add("value1").add("value2").add("value3"))),
+        Arguments.of("mixed array notation and duplicate keys",
+            "items[]=a&items=b&items[]=c",
+            new JsonObject()
+                .put("items", new JsonArray().add("a").add("b").add("c"))),
+        Arguments.of("empty body",
+            "",
+            new JsonObject()),
+        Arguments.of("null body",
+            null,
+            new JsonObject()),
+        Arguments.of("key without value",
+            "key1&key2=value2",
+            new JsonObject()
+                .put("key1", "")
+                .put("key2", "value2")),
+        Arguments.of("value with equals sign",
+            "equation=1%2B1=2&url=http://example.com?a=1%26b=2",
+            new JsonObject()
+                .put("equation", "1+1=2")
+                .put("url", "http://example.com?a=1&b=2")),
+        Arguments.of("JSON object value",
+            "data=%7B%22nested%22%3A%22value%22%2C%22num%22%3A123%7D",
+            new JsonObject()
+                .put("data", new JsonObject().put("nested", "value").put("num", 123))),
+        Arguments.of("JSON array value",
+            "items=%5B1%2C2%2C3%5D&name=test",
+            new JsonObject()
+                .put("items", new JsonArray().add(1).add(2).add(3))
+                .put("name", "test")),
+        Arguments.of("real-world login request",
+            "client_id=26d0bcefd30a4f27897eb9b0e89b53d9"
+                + "&client_secret=76erkSZyFOgBVMDmVlZ5CJpLkOtOly1ufRKK8JiAvArI7rXo3y76DsfyzXE2FJl1"
+                + "&username=admin"
+                + "&password=Vertx%402026",
+            new JsonObject()
+                .put("client_id", "26d0bcefd30a4f27897eb9b0e89b53d9")
+                .put("client_secret", "76erkSZyFOgBVMDmVlZ5CJpLkOtOly1ufRKK8JiAvArI7rXo3y76DsfyzXE2FJl1")
+                .put("username", "admin")
+                .put("password", "Vertx@2026")));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource
+  void testTransform(String description, String body, JsonObject expected) {
+    Buffer buffer = body != null ? Buffer.buffer(body) : null;
+
+    XWwwFormUrlencodedAnalyser analyser =
+        new XWwwFormUrlencodedAnalyser(APPLICATION_X_WWW_FORM_URL_ENCODED, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
+  }
+
+  // ==================== transform - Content-Type variant tests ====================
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      APPLICATION_X_WWW_FORM_URL_ENCODED,
+      APPLICATION_X_WWW_FORM_URL_ENCODED + "; charset=UTF-8",
+  })
+  void testTransformWithVariousContentTypes(String contentType) {
+    String body = "key=value";
+    Buffer buffer = Buffer.buffer(body);
+
+    XWwwFormUrlencodedAnalyser analyser = new XWwwFormUrlencodedAnalyser(contentType, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    JsonObject result = (JsonObject) analyser.transform();
+    assertThat(result.getString("key")).isEqualTo("value");
+  }
+
+  // ==================== transform - complex scenario tests ====================
+
+  @Test
+  void testTransformComplexScenario() throws IOException {
+    Buffer buffer = Buffer.buffer(Files.readString(TEST_RESOURCE_PATH.resolve("form_urlencoded_complex.txt")));
+
+    JsonObject expected = new JsonObject()
+        .put("grant_type", "password")
+        .put("scope", "read:user write:user")
+        .put("roles", new JsonArray().add("admin").add("user"))
+        .put("settings", new JsonObject().put("theme", "dark").put("notifications", true));
+
+    XWwwFormUrlencodedAnalyser analyser =
+        new XWwwFormUrlencodedAnalyser(APPLICATION_X_WWW_FORM_URL_ENCODED, buffer, REQUEST);
+    analyser.checkSyntacticalCorrectness();
+
+    assertThat((JsonObject) analyser.transform()).isEqualTo(expected);
+  }
+}

--- a/src/test/resources/io/vertx/tests/mediatype/impl/form_urlencoded_complex.txt
+++ b/src/test/resources/io/vertx/tests/mediatype/impl/form_urlencoded_complex.txt
@@ -1,0 +1,1 @@
+grant_type=password&scope=read:user write:user&roles[]=admin&roles[]=user&settings=%7B%22theme%22%3A%22dark%22%2C%22notifications%22%3Atrue%7D


### PR DESCRIPTION
Motivation:

application/x-www-form-urlencoded is not included in the default media type registry, which causes issues when implementing OAuth2 token endpoints (RFC 6749 requires this media type).

Conformance:
Added complete support for application/x-www-form-urlencoded media type with a dedicated content analyser.