### PR TITLE
fix: support relative server URLs

### DIFF
--- a/src/main/java/io/vertx/openapi/contract/impl/ServerImpl.java
+++ b/src/main/java/io/vertx/openapi/contract/impl/ServerImpl.java
@@ -18,7 +18,8 @@ import static io.vertx.openapi.contract.OpenAPIContractException.createUnsupport
 import io.vertx.core.json.JsonObject;
 import io.vertx.openapi.contract.Server;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 public class ServerImpl implements Server {
 
@@ -37,8 +38,11 @@ public class ServerImpl implements Server {
       throw createUnsupportedFeature("Server Variables");
     }
     try {
-      this.basePath = new URL(url.endsWith("/") ? url.substring(0, url.length() - 1) : url).getPath();
-    } catch (MalformedURLException e) {
+      URI uri = new URI(url.endsWith("/") ? url.substring(0, url.length() - 1) : url);
+      // The URL may be relative, to indicate that the host location is relative to the location where
+      // the document containing the Server Object is being served.
+      this.basePath = uri.isAbsolute() ? uri.toURL().getPath() : uri.getPath();
+    } catch (URISyntaxException | MalformedURLException | IllegalArgumentException e) {
       throw createInvalidContract("The specified URL is malformed: " + url, e);
     }
   }

--- a/src/test/java/io/vertx/tests/contract/impl/ServerImplTest.java
+++ b/src/test/java/io/vertx/tests/contract/impl/ServerImplTest.java
@@ -45,7 +45,11 @@ public class ServerImplTest {
         Arguments.of("https://example.com/", ""),
         Arguments.of("https://example.com/foo", "/foo"),
         Arguments.of("https://example.com/foo/", "/foo"),
-        Arguments.of("https://example.com/foo/bar", "/foo/bar"));
+        Arguments.of("https://example.com/foo/bar", "/foo/bar"),
+        Arguments.of("/", ""),
+        Arguments.of("/v1/api", "/v1/api"),
+        Arguments.of("/v1/api/", "/v1/api"),
+        Arguments.of("//example.com/foo", "/foo"));
   }
 
   @ParameterizedTest(name = "{index} BasePath extraction: {0} should result into {1}")
@@ -54,6 +58,17 @@ public class ServerImplTest {
     JsonObject model = new JsonObject().put("url", url);
     Server server = new ServerImpl(model);
     assertThat(server.getBasePath()).isEqualTo(basePath);
+  }
+
+  @Test
+  void testRelativeUrlGetters() {
+    String url = "/v1/api";
+    JsonObject model = new JsonObject().put("url", url);
+    Server server = new ServerImpl(model);
+
+    assertThat(server.getOpenAPIModel()).isEqualTo(model);
+    assertThat(server.getURL()).isEqualTo(url);
+    assertThat(server.getBasePath()).isEqualTo("/v1/api");
   }
 
   @Test
@@ -72,5 +87,12 @@ public class ServerImplTest {
             () -> new ServerImpl(new JsonObject().put("url", "http://foo.bar:-80")));
     assertThat(exceptionInvalid.type()).isEqualTo(ContractErrorType.INVALID_SPEC);
     assertThat(exceptionInvalid).hasMessageThat().isEqualTo(msgInvalid);
+
+    String msgInvalidRelative = "The passed OpenAPI contract is invalid: The specified URL is malformed: /v1/ api";
+    OpenAPIContractException exceptionInvalidRelative =
+        assertThrows(OpenAPIContractException.class,
+            () -> new ServerImpl(new JsonObject().put("url", "/v1/ api")));
+    assertThat(exceptionInvalidRelative.type()).isEqualTo(ContractErrorType.INVALID_SPEC);
+    assertThat(exceptionInvalidRelative).hasMessageThat().isEqualTo(msgInvalidRelative);
   }
 }


### PR DESCRIPTION
## Motivation

According to the [OpenAPI specification](https://spec.openapis.org/oas/v3.1.0#server-object), the `url` field of a Server Object *"MAY be relative, to indicate that the host location is relative to the location where the OpenAPI document is being served"*.

However, `ServerImpl` parses the URL with `java.net.URL`, which requires a protocol, so a contract like

```yaml
servers:
  - url: /v1/api
```

is rejected with `The passed OpenAPI contract is invalid: The specified URL is malformed: /v1/api`. This breaks setups where microservices are deployed on dynamic host/port and serve their own swagger-ui, relying on the current location for the scheme/host/port (see #99).

## Changes

Parse the server URL with `java.net.URI` instead:

- Absolute URLs are still validated via `URI#toURL()`, so the existing strict behaviour (e.g. rejecting an invalid port) is unchanged.
- Relative URLs now contribute their path as the base path instead of throwing.

Added test cases for relative (`/`, `/v1/api`, `/v1/api/`), protocol-relative (`//example.com/foo`) and malformed relative (`/v1/ api`) server URLs.

Fixes #99