### PR TITLE
fix: parse multipart parts on byte level to avoid corrupting binary content

### DIFF
--- a/src/main/java/io/vertx/openapi/mediatype/impl/MultipartFormAnalyser.java
+++ b/src/main/java/io/vertx/openapi/mediatype/impl/MultipartFormAnalyser.java
@@ -64,7 +64,7 @@ public class MultipartFormAnalyser extends AbstractContentAnalyser {
       throw new ValidatorException(msg, MISSING_REQUIRED_PARAMETER);
     }
 
-    parts = MultipartPart.fromMultipartBody(content.toString(), boundary);
+    parts = MultipartPart.fromMultipartBody(content, boundary);
   }
 
   @Override

--- a/src/main/java/io/vertx/openapi/mediatype/impl/MultipartPart.java
+++ b/src/main/java/io/vertx/openapi/mediatype/impl/MultipartPart.java
@@ -17,6 +17,7 @@ import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.openapi.validation.ValidatorException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -29,34 +30,81 @@ public class MultipartPart {
       CASE_INSENSITIVE);
   private static final Pattern CONTENT_TYPE_PATTERN = Pattern.compile("Content-Type: (.*)", CASE_INSENSITIVE);
 
+  private static final byte[] HEADER_SECTION_DELIMITER = { '\r', '\n', '\r', '\n' };
+
   private final String name;
   private final String contentType;
   private final Buffer body;
 
-  // Should only be called by MultipartPartFormTransformer
-  static List<MultipartPart> fromMultipartBody(String body, String boundary) {
+  // Should only be called by MultipartFormAnalyser
+  static List<MultipartPart> fromMultipartBody(Buffer body, String boundary) {
     return parseParts(body, boundary).stream().map(MultipartPart::parsePart).collect(Collectors.toList());
   }
 
   // VisibleForTesting
-  public static List<String> parseParts(String body, String boundary) {
-    String delimiter = "--" + boundary + "|\r\n--" + boundary;
-    String[] rawParts = body.split(delimiter);
+  public static List<Buffer> parseParts(Buffer body, String boundary) {
+    // The parts must be split on byte level, because bodies of binary parts could contain byte sequences
+    // that are invalid in UTF-8 and would get corrupted by a String round trip.
+    byte[] bytes = body.getBytes();
+    byte[] delimiter = ("--" + boundary).getBytes(StandardCharsets.US_ASCII);
+    byte[] delimiterWithLineBreak = ("\r\n--" + boundary).getBytes(StandardCharsets.US_ASCII);
 
-    if (rawParts.length < 3 || !"--".equals(rawParts[rawParts.length - 1].strip())) {
+    List<Buffer> rawParts = new ArrayList<>();
+    int segmentStart = 0;
+    int i = 0;
+    while (i < bytes.length) {
+      // The line break preceding the delimiter belongs to the delimiter, not to the part body.
+      byte[] match = matchesAt(bytes, i, delimiter) ? delimiter
+          : matchesAt(bytes, i, delimiterWithLineBreak) ? delimiterWithLineBreak : null;
+      if (match == null) {
+        i++;
+      } else {
+        rawParts.add(body.getBuffer(segmentStart, i));
+        i += match.length;
+        segmentStart = i;
+      }
+    }
+    rawParts.add(body.getBuffer(segmentStart, bytes.length));
+
+    if (rawParts.size() < 3 || !"--".equals(rawParts.get(rawParts.size() - 1).toString().strip())) {
       String msg = "The multipart message doesn't contain any parts, or has an invalid structure.";
       throw new ValidatorException(msg, INVALID_VALUE);
     }
 
-    List<String> parts = new ArrayList<>(rawParts.length - 2);
+    List<Buffer> parts = new ArrayList<>(rawParts.size() - 2);
 
     // Omit first and last part, because first part is everything up to the first delimiter and the last part
     // contains "--";
-    for (int i = 1; i < rawParts.length - 1; i++) {
-      parts.add(rawParts[i].strip());
+    for (int j = 1; j < rawParts.size() - 1; j++) {
+      parts.add(stripLeadingWhitespace(rawParts.get(j)));
     }
 
     return parts;
+  }
+
+  private static boolean matchesAt(byte[] bytes, int offset, byte[] pattern) {
+    if (offset + pattern.length > bytes.length) {
+      return false;
+    }
+    for (int i = 0; i < pattern.length; i++) {
+      if (bytes[offset + i] != pattern[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static Buffer stripLeadingWhitespace(Buffer rawPart) {
+    int start = 0;
+    while (start < rawPart.length()) {
+      byte b = rawPart.getByte(start);
+      if (b == ' ' || b == '\t' || b == '\r' || b == '\n') {
+        start++;
+      } else {
+        break;
+      }
+    }
+    return rawPart.getBuffer(start, rawPart.length());
   }
 
   private static Optional<String> parsePattern(Pattern pattern, String rawPart) {
@@ -64,14 +112,21 @@ public class MultipartPart {
   }
 
   // VisibleForTesting
-  public static MultipartPart parsePart(String rawPart) {
-    String sectionDelimiterPattern = "\r\n\r\n";
-    int sectionDelimiter = rawPart.indexOf(sectionDelimiterPattern);
+  public static MultipartPart parsePart(Buffer rawPart) {
+    int sectionDelimiter = -1;
+    byte[] bytes = rawPart.getBytes();
+    for (int i = 0; i < bytes.length; i++) {
+      if (matchesAt(bytes, i, HEADER_SECTION_DELIMITER)) {
+        sectionDelimiter = i;
+        break;
+      }
+    }
 
     // if no empty line exists, there are only headers
-    String headerSection = sectionDelimiter == -1 ? rawPart : rawPart.substring(0, sectionDelimiter);
-    String body =
-        sectionDelimiter == -1 ? null : rawPart.substring(sectionDelimiter + sectionDelimiterPattern.length());
+    String headerSection = sectionDelimiter == -1 ? rawPart.toString()
+        : rawPart.getBuffer(0, sectionDelimiter).toString();
+    Buffer body = sectionDelimiter == -1 ? null
+        : rawPart.getBuffer(sectionDelimiter + HEADER_SECTION_DELIMITER.length, rawPart.length());
 
     String name = parsePattern(NAME_PATTERN, headerSection).orElseThrow(() -> {
       String msg = "A part of the multipart message doesn't contain a name.";
@@ -81,7 +136,7 @@ public class MultipartPart {
     // If no header is set, content type defaults to text/plain
     String contentType = parsePattern(CONTENT_TYPE_PATTERN, headerSection).orElse("text/plain");
 
-    return new MultipartPart(name, contentType, body == null ? null : Buffer.buffer(body));
+    return new MultipartPart(name, contentType, body == null || body.length() == 0 ? null : body);
   }
 
   public MultipartPart(String name, String contentType, Buffer body) {

--- a/src/test/java/io/vertx/tests/mediatype/impl/MultipartFormAnalyserTest.java
+++ b/src/test/java/io/vertx/tests/mediatype/impl/MultipartFormAnalyserTest.java
@@ -111,6 +111,29 @@ class MultipartFormAnalyserTest {
   }
 
   @Test
+  void testTransformOctetStreamWithBinaryContent() {
+    // Contains bytes that are invalid in UTF-8 (e.g. 0x89, 0xFF) and whitespace bytes at the edges,
+    // which must survive the transformation unmodified.
+    byte[] binaryContent = { 0x0A, 0x20, (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00,
+        (byte) 0xFF, (byte) 0xFE, 0x42, 0x09, 0x20, 0x0D, 0x0A };
+
+    Buffer multipartBody = Buffer.buffer()
+        .appendString("--abcde12345\r\n")
+        .appendString("Content-Disposition: form-data; name=\"file\"; filename=\"blob.bin\"\r\n")
+        .appendString("Content-Type: application/octet-stream\r\n")
+        .appendString("\r\n")
+        .appendBytes(binaryContent)
+        .appendString("\r\n--abcde12345--");
+    String contentType = "multipart/form-data; boundary=abcde12345";
+
+    MultipartFormAnalyser analyser = new MultipartFormAnalyser(contentType, multipartBody, REQUEST);
+    analyser.checkSyntacticalCorrectness(); // must always be executed before transform
+
+    JsonObject result = (JsonObject) analyser.transform();
+    assertThat(result.getBuffer("file")).isEqualTo(Buffer.buffer(binaryContent));
+  }
+
+  @Test
   void testTransformContinueWhenBodyEmpty() throws IOException {
     Buffer multipartBody = Buffer.buffer(Files.readString(TEST_RESOURCE_PATH.resolve("multipart_id_no_body.txt")));
     String contentType = "multipart/form-data; boundary=abcde12345";

--- a/src/test/java/io/vertx/tests/mediatype/impl/MultipartPartTest.java
+++ b/src/test/java/io/vertx/tests/mediatype/impl/MultipartPartTest.java
@@ -32,19 +32,23 @@ import org.junit.jupiter.params.provider.ValueSource;
 class MultipartPartTest {
   private static final Path TEST_RESOURCE_PATH = getRelatedTestResourcePath(MultipartPartTest.class);
 
+  private static Buffer readResource(String file) throws IOException {
+    return Buffer.buffer(Files.readAllBytes(TEST_RESOURCE_PATH.resolve(file)));
+  }
+
   @Test
   void testParseParts() throws IOException {
-    String part1 = Files.readString(TEST_RESOURCE_PATH.resolve("part1.txt"));
-    String part2 = Files.readString(TEST_RESOURCE_PATH.resolve("part2.txt"));
+    Buffer part1 = readResource("part1.txt");
+    Buffer part2 = readResource("part2.txt");
 
-    String multipartBody = Files.readString(TEST_RESOURCE_PATH.resolve("multipart.txt"));
+    Buffer multipartBody = readResource("multipart.txt");
     Truth.assertThat(MultipartPart.parseParts(multipartBody, "abcde12345")).containsExactly(part1, part2);
   }
 
   @ParameterizedTest
   @ValueSource(strings = { "multipart_invalid_structure", "multipart_invalid_structure_2" })
   void testParsePartsInvalidStructure(String file) throws IOException {
-    String multipartBody = Files.readString(TEST_RESOURCE_PATH.resolve(file + ".txt"));
+    Buffer multipartBody = readResource(file + ".txt");
 
     ValidatorException exception =
         assertThrows(ValidatorException.class, () -> MultipartPart.parseParts(multipartBody, "abcde12345"));
@@ -56,13 +60,13 @@ class MultipartPartTest {
 
   @Test
   void testParsePart() throws IOException {
-    String part1 = Files.readString(TEST_RESOURCE_PATH.resolve("part1.txt"));
+    Buffer part1 = readResource("part1.txt");
     MultipartPart mpp1 = MultipartPart.parsePart(part1);
     assertThat(mpp1.getName()).isEqualTo("id");
     assertThat(mpp1.getContentType()).isEqualTo("text/plain");
     assertThat(mpp1.getBody()).isEqualTo(Buffer.buffer("123e4567-e89b-12d3-a456-426655440000"));
 
-    String part2 = Files.readString(TEST_RESOURCE_PATH.resolve("part2.txt"));
+    Buffer part2 = readResource("part2.txt");
     MultipartPart mpp2 = MultipartPart.parsePart(part2);
     assertThat(mpp2.getName()).isEqualTo("address");
     assertThat(mpp2.getContentType()).isEqualTo("application/json");
@@ -71,7 +75,7 @@ class MultipartPartTest {
         .put("city", "Hillsbery, UT");
     assertThat(mpp2.getBody().toJsonObject()).isEqualTo(body);
 
-    String part3 = Files.readString(TEST_RESOURCE_PATH.resolve("part3.txt"));
+    Buffer part3 = readResource("part3.txt");
     MultipartPart mpp3 = MultipartPart.parsePart(part3);
     assertThat(mpp3.getName()).isEqualTo("randomBinary");
     assertThat(mpp3.getContentType()).isEqualTo("application/octet-stream");
@@ -80,7 +84,7 @@ class MultipartPartTest {
 
   @Test
   void testParsePartWithoutName() throws IOException {
-    String part = Files.readString(TEST_RESOURCE_PATH.resolve("part_without_name.txt"));
+    Buffer part = readResource("part_without_name.txt");
 
     ValidatorException exception =
         assertThrows(ValidatorException.class, () -> MultipartPart.parsePart(part));
@@ -92,7 +96,7 @@ class MultipartPartTest {
 
   @Test
   void testParsePartWithoutContentType() throws IOException {
-    String part = Files.readString(TEST_RESOURCE_PATH.resolve("part_without_contenttype.txt"));
+    Buffer part = readResource("part_without_contenttype.txt");
 
     MultipartPart mpp = MultipartPart.parsePart(part);
     assertThat(mpp.getName()).isEqualTo("id");
@@ -102,7 +106,7 @@ class MultipartPartTest {
 
   @Test
   void testParsePartWithoutBody() throws IOException {
-    String part = Files.readString(TEST_RESOURCE_PATH.resolve("part_without_body.txt"));
+    Buffer part = readResource("part_without_body.txt");
     MultipartPart mpp = MultipartPart.parsePart(part);
     assertThat(mpp.getName()).isEqualTo("id");
     assertThat(mpp.getContentType()).isEqualTo("text/plain");


### PR DESCRIPTION
## Motivation

Uploading a binary file (PDF, XLSX, PNG, ...) through a `multipart/form-data` request body corrupts the file (#85, #119). There are two corruption vectors in the current implementation:

1. `MultipartFormAnalyser` decodes the complete multipart body into a UTF-8 `String` before splitting it into parts. Every byte sequence that is not valid UTF-8 is replaced with the replacement character during decoding, so the original bytes are unrecoverable.
2. `MultipartPart#parseParts` calls `String#strip()` on each raw part, which also removes whitespace *bytes* (`0x09`, `0x0A`, `0x0D`, `0x20`, ...) from the beginning and end of binary part bodies.

## Changes

- `MultipartPart` now splits the multipart body on byte level (`Buffer`-based). Only the header section of a part is decoded into a `String` for header parsing.
- The line break preceding a delimiter is treated as belonging to the delimiter (per RFC 2046), so part bodies are passed through byte for byte — no stripping.
- The error behaviour is unchanged: same exceptions and messages for invalid structure, missing part name and empty bodies (empty body still results in the part being skipped).
- The `String`-based `MultipartPart` methods were replaced with `Buffer`-based equivalents; the package is only exported to the test modules, so no public API is affected.

Added a regression test that round-trips a body containing invalid-UTF-8 bytes and whitespace bytes at the body edges, which fails against the previous implementation.

Fixes #85
Fixes #119