### PR TITLE
fix: extract path parameters correctly when the router is mounted as subrouter

### DIFF
--- a/src/main/java/io/vertx/openapi/validation/RequestUtils.java
+++ b/src/main/java/io/vertx/openapi/validation/RequestUtils.java
@@ -79,8 +79,9 @@ public class RequestUtils {
           headers.put(param.getName(), extractHeaders(request, param));
           break;
         case PATH:
-          int segment = findPathSegment(operation.getAbsoluteOpenAPIPath(), param.getName());
-          pathParams.put(param.getName(), extractPathParameters(param, request, segment));
+          String templatePath = operation.getAbsoluteOpenAPIPath();
+          int segment = findPathSegment(templatePath, param.getName());
+          pathParams.put(param.getName(), extractPathParameters(request, segment, countPathSegments(templatePath)));
           break;
         case QUERY:
           query.put(param.getName(), extractQuery(request, param));
@@ -119,12 +120,17 @@ public class RequestUtils {
     return new RequestParameterImpl(urlDecodeIfRequired(parameter, headerValue));
   }
 
-  private static RequestParameter extractPathParameters(Parameter param, HttpServerRequest request, int segment) {
+  private static RequestParameter extractPathParameters(HttpServerRequest request, int segment,
+      int templatePathSegments) {
     String[] pathSegments = request.path().substring(1).split("/");
-    if (pathSegments.length < segment) {
+    // The router the operation is attached to may be mounted as a subrouter. In that case the request path
+    // contains additional leading segments that are not part of the OpenAPI path template.
+    int mountOffset = Math.max(0, pathSegments.length - templatePathSegments);
+    int index = mountOffset + segment;
+    if (pathSegments.length < index) {
       return EMPTY;
     }
-    return new RequestParameterImpl(decodeUrl(pathSegments[segment - 1]));
+    return new RequestParameterImpl(decodeUrl(pathSegments[index - 1]));
   }
 
   /**
@@ -170,6 +176,10 @@ public class RequestUtils {
   public static int findPathSegment(String templatePath, String parameterName) {
     int idx = templatePath.indexOf("{" + parameterName + "}");
     return (int) templatePath.subSequence(0, idx).chars().filter(c -> c == '/').count();
+  }
+
+  private static int countPathSegments(String templatePath) {
+    return (int) templatePath.chars().filter(c -> c == '/').count();
   }
 
   static String urlDecodeIfRequired(Parameter param, String value) {

--- a/src/test/java/io/vertx/tests/validation/RequestUtilsTest.java
+++ b/src/test/java/io/vertx/tests/validation/RequestUtilsTest.java
@@ -231,6 +231,29 @@ class RequestUtilsTest extends HttpServerTestBase {
     Truth.assertThat(RequestUtils.findPathSegment(templatePath, parameterName)).isEqualTo(expected);
   }
 
+  private static Stream<Arguments> testExtractPathFromMountedRouter() {
+    return Stream.of(
+        Arguments.of("/my-service", "/test/5.7"),
+        Arguments.of("/my-service", "/test/5.7/"),
+        Arguments.of("/deeply/nested/mount/point", "/test/5.7"));
+  }
+
+  @ParameterizedTest(name = "{index} Path parameter should be extracted from {0}{1}")
+  @MethodSource
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void testExtractPathFromMountedRouter(String mountPoint, String path, VertxTestContext testContext) {
+    Parameter parameter = mockParameter("foo", PATH, NUMBER, false);
+    Operation mockedOperation = mockOperation(parameter);
+    when(mockedOperation.getAbsoluteOpenAPIPath()).thenReturn("/test/{foo}");
+
+    createValidationHandler(params -> {
+      Truth.assertThat(params.getPathParameters().get(parameter.getName()).getString()).isEqualTo("5.7");
+      testContext.completeNow();
+    }, mockedOperation, testContext).compose(
+        v -> createRequest(HttpMethod.GET, mountPoint + path).map(HttpClientRequest::send))
+        .onFailure(testContext::failNow);
+  }
+
   @Test
   @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
   void testBodySupplier(VertxTestContext testContext) {


### PR DESCRIPTION
## Motivation

As reported in #120: `RequestUtils` calculates the position of a path parameter from the beginning of the OpenAPI path template (`/entities/{id}` → segment 2) and applies it to the path of the incoming request. When the router built from the contract is mounted as a subrouter (e.g. `mainRouter.route("/my-service/*").subRouter(router)`), the request path (`/my-service/entities/5`) contains additional leading segments, so the calculated position points to the wrong segment. Validation then either fails with a confusing type error or — worse — silently validates the wrong value (for `string` parameters).

## Changes

Mounting a router can only *prepend* segments to the request path, so the number of additional leading segments can be determined by comparing the segment count of the request path with the segment count of the path template. The parameter position is now shifted by this mount offset:

- Routers mounted as subrouter (at any depth) now extract path parameters correctly, with and without trailing slash.
- For routers that are not mounted, the offset is `0` and the behaviour is unchanged — including the existing handling of empty path parameters.
- Also removed the unused `Parameter` argument of `extractPathParameters` that was mentioned in the issue discussion.

One limitation worth being transparent about: a *mounted* router receiving an **empty** trailing path parameter (`/my-service/test/`) remains ambiguous, because without knowing the mount point the extra segments cannot be distinguished from the parameter itself. Resolving that fully would require the mount information from `vertx-web` (see vert-x3/vertx-web#2694). This change fixes the practically relevant cases without any API change.

Fixes #120