### PR TITLE
fix: extract path parameters correctly when the router is mounted as …

### DIFF
--- a/src/main/java/io/vertx/openapi/validation/RequestUtils.java
+++ b/src/main/java/io/vertx/openapi/validation/RequestUtils.java
@@ -79,8 +79,9 @@ public class RequestUtils {
           headers.put(param.getName(), extractHeaders(request, param));
           break;
         case PATH:
-          int segment = findPathSegment(operation.getAbsoluteOpenAPIPath(), param.getName());
-          pathParams.put(param.getName(), extractPathParameters(param, request, segment));
+          String templatePath = operation.getAbsoluteOpenAPIPath();
+          int segment = findPathSegment(templatePath, param.getName());
+          pathParams.put(param.getName(), extractPathParameters(request, segment, countPathSegments(templatePath)));
           break;
         case QUERY:
           query.put(param.getName(), extractQuery(request, param));
@@ -119,12 +120,17 @@ public class RequestUtils {
     return new RequestParameterImpl(urlDecodeIfRequired(parameter, headerValue));
   }
 
-  private static RequestParameter extractPathParameters(Parameter param, HttpServerRequest request, int segment) {
+  private static RequestParameter extractPathParameters(HttpServerRequest request, int segment,
+      int templatePathSegments) {
     String[] pathSegments = request.path().substring(1).split("/");
-    if (pathSegments.length < segment) {
+    // The router the operation is attached to may be mounted as a subrouter. In that case the request path
+    // contains additional leading segments that are not part of the OpenAPI path template.
+    int mountOffset = Math.max(0, pathSegments.length - templatePathSegments);
+    int index = mountOffset + segment;
+    if (pathSegments.length < index) {
       return EMPTY;
     }
-    return new RequestParameterImpl(decodeUrl(pathSegments[segment - 1]));
+    return new RequestParameterImpl(decodeUrl(pathSegments[index - 1]));
   }
 
   /**
@@ -170,6 +176,10 @@ public class RequestUtils {
   public static int findPathSegment(String templatePath, String parameterName) {
     int idx = templatePath.indexOf("{" + parameterName + "}");
     return (int) templatePath.subSequence(0, idx).chars().filter(c -> c == '/').count();
+  }
+
+  private static int countPathSegments(String templatePath) {
+    return (int) templatePath.chars().filter(c -> c == '/').count();
   }
 
   static String urlDecodeIfRequired(Parameter param, String value) {

--- a/src/test/java/io/vertx/tests/validation/RequestUtilsTest.java
+++ b/src/test/java/io/vertx/tests/validation/RequestUtilsTest.java
@@ -231,6 +231,29 @@ class RequestUtilsTest extends HttpServerTestBase {
     Truth.assertThat(RequestUtils.findPathSegment(templatePath, parameterName)).isEqualTo(expected);
   }
 
+  private static Stream<Arguments> testExtractPathFromMountedRouter() {
+    return Stream.of(
+        Arguments.of("/my-service", "/test/5.7"),
+        Arguments.of("/my-service", "/test/5.7/"),
+        Arguments.of("/deeply/nested/mount/point", "/test/5.7"));
+  }
+
+  @ParameterizedTest(name = "{index} Path parameter should be extracted from {0}{1}")
+  @MethodSource
+  @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+  void testExtractPathFromMountedRouter(String mountPoint, String path, VertxTestContext testContext) {
+    Parameter parameter = mockParameter("foo", PATH, NUMBER, false);
+    Operation mockedOperation = mockOperation(parameter);
+    when(mockedOperation.getAbsoluteOpenAPIPath()).thenReturn("/test/{foo}");
+
+    createValidationHandler(params -> {
+      Truth.assertThat(params.getPathParameters().get(parameter.getName()).getString()).isEqualTo("5.7");
+      testContext.completeNow();
+    }, mockedOperation, testContext).compose(
+        v -> createRequest(HttpMethod.GET, mountPoint + path).map(HttpClientRequest::send))
+        .onFailure(testContext::failNow);
+  }
+
   @Test
   @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
   void testBodySupplier(VertxTestContext testContext) {


### PR DESCRIPTION
…subrouter

The position of a path parameter was calculated from the beginning of the OpenAPI path template and applied to the path of the incoming request. When the router built from the contract is mounted as a subrouter, the request path contains additional leading segments, so the calculated position pointed to the wrong segment and validation failed or, even worse, validated the wrong value.

Since mounting a router can only prepend segments to the request path, the number of additional leading segments is now determined by comparing the number of segments of the request path with the number of segments of the path template, and the parameter position is shifted accordingly. For routers that are not mounted as subrouter the behaviour is unchanged.

Fixes #120

(cherry picked from commit 2c6129374e1176d367b2d8b1e538082014af592e)

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
